### PR TITLE
Extend CI

### DIFF
--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -1,4 +1,4 @@
-name: Test-TypeART
+name: TypeART-CI
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-run-test:
     runs-on: ubuntu-18.04
-
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
       - uses: actions/checkout@v2
 
@@ -19,10 +19,13 @@ jobs:
           sudo apt-get update -q
 
       - name: Install LLVM
-        run: sudo apt-get install libllvm10 llvm-10 llvm-10-dev llvm-10-runtime
+        run: sudo apt-get install libllvm10 llvm-10 llvm-10-dev
 
       - name: Install Clang
-        run: sudo apt-get install clang-10 clang-format-10 clang-tidy-10
+        run: sudo apt-get install clang-10
+
+      - name: Install OpenMPI
+        run: sudo apt-get install libopenmpi-dev openmpi-bin
 
       - name: Setup env
         run: |
@@ -33,32 +36,35 @@ jobs:
           sudo ln -f -s /usr/bin/llc-10 /usr/bin/llc
           echo "::set-env name=CC::clang-10"
           echo "::set-env name=CXX::clang++-10"
-          echo "::set-env name=EXT_LIT::/usr/lib/llvm-10/build/utils/lit/lit.py"
+          echo "::set-env name=EXTERNAL_LIT::/usr/lib/llvm-10/build/utils/lit/lit.py"
 
       - name: Build TypeART
         run: |
-          cmake -B build -DTEST_CONFIG=ON -DLLVM_EXTERNAL_LIT=${EXT_LIT}
+          cmake -B build -DTEST_CONFIG=ON -DLLVM_EXTERNAL_LIT=${EXTERNAL_LIT}
           cmake --build build --parallel
 
       - name: Test TypeART
         run: cmake --build build --target test -- ARGS=-VV
 
-      - name: Run tidy checks
+      - name: Build TypeART Release
         run: |
-          cmake --build build --target tidy-run-on-typeartpass        | tee tidy_typeartpass.txt    | tee -a tidy_all.txt
-          cmake --build build --target tidy-run-on-meminstfinderpass  | tee tidy_meminstfinder.txt  | tee -a tidy_all.txt
-          cmake --build build --target tidy-run-on-typelib            | tee tidy_typelib.txt        | tee -a tidy_all.txt
-          cmake --build build --target tidy-run-on-typeart-rt         | tee tidy_typeart-rt.txt     | tee -a tidy_all.txt
+          cmake -B build_lulesh -DCMAKE_BUILD_TYPE=Release -DMPI_INTERCEPT_LIB=ON -DSHOW_STATS=ON
+          cmake --build build_lulesh --parallel
 
-      - name: Prepare clang-tidy artifact
+      - name: Test TypeART on lulesh
+        working-directory: build_lulesh
+        run: ctest -V -R lulesh -O lulesh2.0_build.log
+        
+      - name: Prepare lulesh artifact
         run: |
-          mkdir artifact
-          mv tidy_* artifact/
+          mkdir artifact_lulesh
+          mv build_lulesh/lulesh2.0_build.log artifact_lulesh/
+          mv test/lulesh/lulesh2.0_out.log artifact_lulesh/
+          mv test/lulesh/types.yaml artifact_lulesh/lulesh2.0_types.yaml
 
-      - name: Upload clang-tidy artifact
+      - name: Upload lulesh test artifact
         uses: actions/upload-artifact@v1
         with:
-          name: typeart-clangtidy-archive
-          path: artifact
-        
+          name: typeart-lulesh-archive
+          path: artifact_lulesh
         

--- a/.github/workflows/ext-ci.yml
+++ b/.github/workflows/ext-ci.yml
@@ -1,0 +1,85 @@
+name: TypeART-CI-ext
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build-and-run-testbench:
+    runs-on: ubuntu-18.04
+    if: "!contains(github.event.head_commit.message, '[ci skip]') || !contains(github.event.head_commit.message, '[ci ext skip]')"
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Checkout test-bench
+        uses: actions/checkout@v2
+        with:
+          repository: tudasc/typeart-bench
+          ssh-key: ${{ secrets.AUTH_SSH_CI_EXT }}
+          path: test-bench
+
+      - name: Setup LLVM repository
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null | sudo apt-key add -
+          sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main' -y
+          sudo apt-get update -q
+
+      - name: Install LLVM
+        run: sudo apt-get install libllvm10 llvm-10 llvm-10-dev
+
+      - name: Install Clang
+        run: sudo apt-get install clang-10
+
+      - name: Install OpenMPI
+        run: sudo apt-get install libopenmpi-dev openmpi-bin
+
+      - name: Setup env
+        run: |
+          sudo ln -f -s /usr/bin/clang-10 /usr/bin/clang
+          sudo ln -f -s /usr/bin/clang++-10 /usr/bin/clang++
+          sudo ln -f -s /usr/bin/opt-10 /usr/bin/opt
+          sudo ln -f -s /usr/bin/llc-10 /usr/bin/llc
+          echo "::set-env name=CC::clang-10"
+          echo "::set-env name=CXX::clang++-10"
+
+      - name: Build & install TypeART
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=Release -DMPI_INTERCEPT_LIB=ON -DSHOW_STATS=ON
+          cmake --build build --parallel --target install
+          echo "::set-env name=TYPEART_PATH::${GITHUB_WORKSPACE}/install/typeart"
+
+      - name: Setup tests
+        working-directory: test-bench
+        run: cmake -B build -DLOG_PATH=${GITHUB_WORKSPACE}/test-bench/artifact
+
+      - name: Run lulesh
+        working-directory: test-bench/build
+        run: ctest -V -R lulesh -O lulesh2.0_build.log
+
+      - name: Run 104.milc
+        working-directory: test-bench/build
+        run: ctest -V -R 104.milc -O 104.milc_build.log
+
+      - name: Run 122.tachyon
+        working-directory: test-bench/build
+        run: ctest -V -R 122.tachyon -O 122.tachyon_build.log
+
+      - name: Run amg2013
+        working-directory: test-bench/build
+        run: ctest -V -R amg2013 -O amg2013_build.log
+
+      - name: Prepare test-bench artifact
+        working-directory: test-bench
+        run: |
+          mkdir -p artifact
+          mv build/*_build.log artifact
+
+      - name: Upload test-bench artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: typeart-bench-archive
+          path: test-bench/artifact
+        
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TypeART &nbsp; [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) &nbsp; ![](https://github.com/tudasc/TypeART/workflows/Test-TypeART/badge.svg?branch=master)
+# TypeART &nbsp; [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) &nbsp; ![](https://github.com/tudasc/TypeART/workflows/TypeART-CI/badge.svg?branch=master) &nbsp; ![](https://github.com/tudasc/TypeART/workflows/TypeART-CI-ext/badge.svg?branch=master)
 
 TypeART \[[TA18](#ref-typeart-2018)\] is a type and memory allocation tracking sanitizer.
 It consists of an LLVM compiler pass and a corresponding runtime to track relevant memory allocation information during the execution of a target program.


### PR DESCRIPTION
- remove clang-tidy runs (will be added separately, later)
- test lulesh2.0 in the basic ci setup
- extended CI testing for push to master, and PRs
  - test bench includes apps from the TA18 paper