### PR TITLE
Feat/rt cleanup

### DIFF
--- a/runtime/AccessCounter.h
+++ b/runtime/AccessCounter.h
@@ -110,7 +110,11 @@ class AccessRecorder {
     ++nullAndZeroAlloc;
   }
 
-  static AccessRecorder& get() {
+  inline void incUDefTypes(size_t count) {
+    numUDefTypes += count;
+  }
+
+  [[nodiscard]] static AccessRecorder& get() {
     static AccessRecorder instance;
     return instance;
   }
@@ -140,6 +144,7 @@ class AccessRecorder {
   Counter nullAlloc        = 0;
   Counter zeroAlloc        = 0;
   Counter nullAndZeroAlloc = 0;
+  Counter numUDefTypes     = 0;
   std::unordered_set<MemAddr> missing;
   std::unordered_set<MemAddr> seen;
   TypeCountMap stackAlloc;
@@ -182,6 +187,8 @@ class NoneRecorder {
   [[maybe_unused]] inline void incZeroLengthAddr() {
   }
   [[maybe_unused]] inline void incZeroLengthAndNullAddr() {
+  }
+  [[maybe_unused]] inline void incUDefTypes(size_t count) {
   }
 
   static NoneRecorder& get() {
@@ -234,6 +241,7 @@ void serialise(const Recorder& r, llvm::raw_ostream& buf) {
     t.put(Row::make("Total free heap", r.heapAllocsFree, r.heapArrayFree));
     t.put(Row::make("Total free stack", r.stackAllocsFree, r.stackArrayFree));
     t.put(Row::make("Null/Zero/NullZero Addr", r.nullAlloc, r.zeroAlloc, r.nullAndZeroAlloc));
+    t.put(Row::make("User-def. types", r.numUDefTypes));
     t.put(Row::make("Estimated memory use (KiB)", size_t(std::round(memory_use.map + memory_use.stack))));
     t.put(Row::make("Bytes per node map/stack", memory::MemOverhead::perNodeSizeMap,
                     memory::MemOverhead::perNodeSizeStack));

--- a/runtime/CallbackInterface.h
+++ b/runtime/CallbackInterface.h
@@ -11,6 +11,7 @@
 #include <stddef.h>
 #endif
 
+// Callback function signatures invoked by the LLVM pass
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/runtime/CallbackInterface.h
+++ b/runtime/CallbackInterface.h
@@ -1,0 +1,26 @@
+//
+// Created by ahueck on 16.10.20.
+//
+
+#ifndef TYPEART_CALLBACKINTERFACE_H
+#define TYPEART_CALLBACKINTERFACE_H
+
+#ifdef __cplusplus
+#include <cstddef>
+#else
+#include <stddef.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+void __typeart_alloc(const void* addr, int typeId, size_t count);
+void __typeart_alloc_stack(const void* addr, int typeId, size_t count);
+void __typeart_alloc_global(const void* addr, int typeId, size_t count);
+void __typeart_free(const void* addr);
+void __typeart_leave_scope(size_t alloca_count);
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TYPEART_CALLBACKINTERFACE_H

--- a/runtime/Runtime.cpp
+++ b/runtime/Runtime.cpp
@@ -535,7 +535,7 @@ void TypeArtRT::onFreeHeap(const void* addr, const void* retAddr) {
 }
 
 void TypeArtRT::onLeaveScope(size_t alloca_count, const void* retAddr) {
-  if (alloca_count > stackVars.size()) {
+  if (unlikely(alloca_count > stackVars.size())) {
     LOG_ERROR("Stack is smaller than requested de-allocation count. alloca_count: " << alloca_count
                                                                                     << ". size: " << stackVars.size());
     alloca_count = stackVars.size();

--- a/runtime/Runtime.cpp
+++ b/runtime/Runtime.cpp
@@ -17,6 +17,9 @@
 using namespace btree;
 #endif
 
+#define likely(x) __builtin_expect(!!(x), 1)
+#define unlikely(x) __builtin_expect(!!(x), 0)
+
 namespace typeart {
 /**
  * Ensures that memory tracking functions do not come from within the runtime.
@@ -34,27 +37,76 @@ static bool typeart_rt_scope{false};
 
 namespace typeart {
 
-std::string TypeArtRT::defaultTypeFileName{"types.yaml"};
+// std::string TypeArtRT::defaultTypeFileName{"types.yaml"};
 
 template <typename T>
 inline const void* addByteOffset(const void* addr, T offset) {
   return static_cast<const void*>(static_cast<const uint8_t*>(addr) + offset);
 }
 
-inline static std::string toString(const void* addr, int typeId, size_t count, size_t typeSize) {
-  std::stringstream s;
-  // clang-format off
-  s << addr
-    << ". typeId: " << typeId << " (" << TypeArtRT::get().getTypeName(typeId) << ")"
-    << ". count: " << count
-    << ". typeSize " << typeSize;
-  // clang-format on
+inline static std::string toString(const void* memAddr, int typeId, size_t count, size_t typeSize,
+                                   const void* calledFrom) {
+  std::string buf;
+  llvm::raw_string_ostream s(buf);
+  const auto name = TypeArtRT::get().getTypeName(typeId);
+  s << memAddr << " " << typeId << " " << name << " " << typeSize << " "
+    << " " << count << " (" << calledFrom << ")";
   return s.str();
+}
+
+inline static std::string toString(const void* memAddr, int typeId, size_t count, const void* calledFrom) {
+  const auto typeSize = TypeArtRT::get().getTypeSize(typeId);
+  return toString(memAddr, typeId, count, typeSize, calledFrom);
 }
 
 inline static std::string toString(const void* addr, const PointerInfo& info) {
   auto typeSize = TypeArtRT::get().getTypeSize(info.typeId);
-  return toString(addr, info.typeId, info.count, typeSize);
+  return toString(addr, info.typeId, info.count, typeSize, info.debug);
+}
+
+namespace detail {
+template <class...>
+constexpr std::false_type always_false{};
+}
+
+template <typename Enum>
+inline Enum operator|(Enum lhs, Enum rhs) {
+  if constexpr (std::is_enum_v<Enum> &&
+                (std::is_same_v<Enum, TypeArtRT::AllocState> || std::is_same_v<Enum, TypeArtRT::FreeState>)) {
+    using enum_t = typename std::underlying_type<Enum>::type;
+    return static_cast<Enum>(static_cast<enum_t>(lhs) | static_cast<enum_t>(rhs));
+  } else {
+    static_assert(detail::always_false<Enum>);
+  }
+}
+template <typename Enum>
+inline void operator|=(Enum& lhs, Enum rhs) {
+  if constexpr (std::is_enum_v<Enum> &&
+                (std::is_same_v<Enum, TypeArtRT::AllocState> || std::is_same_v<Enum, TypeArtRT::FreeState>)) {
+    lhs = lhs | rhs;
+  } else {
+    static_assert(detail::always_false<Enum>);
+  }
+}
+
+template <typename Enum>
+inline Enum operator&(Enum lhs, Enum rhs) {
+  if constexpr (std::is_enum_v<Enum> && std::is_same_v<Enum, TypeArtRT::AllocState>) {
+    using enum_t = typename std::underlying_type<Enum>::type;
+    return static_cast<Enum>(static_cast<enum_t>(lhs) & static_cast<enum_t>(rhs));
+  } else {
+    static_assert(detail::always_false<Enum>);
+  }
+}
+
+template <typename Enum>
+inline typename std::underlying_type<Enum>::type operator==(Enum lhs, Enum rhs) {
+  if constexpr (std::is_enum_v<Enum> && std::is_same_v<Enum, TypeArtRT::AllocState>) {
+    using enum_t = typename std::underlying_type<Enum>::type;
+    return static_cast<enum_t>(lhs) & static_cast<enum_t>(rhs);
+  } else {
+    static_assert(detail::always_false<Enum>);
+  }
 }
 
 TypeArtRT::TypeArtRT(Recorder& counter) : counter(counter) {
@@ -372,86 +424,108 @@ void TypeArtRT::getReturnAddress(const void* addr, const void** retAddr) const {
   }
 }
 
-void TypeArtRT::doAlloc(const void* addr, int typeId, size_t count, const void* retAddr, const char reg) {
-  if (!typeDB.isValid(typeId)) {
-    LOG_ERROR("Allocation of unknown type (id=" << typeId << ") recorded at " << addr << " [" << reg
-                                                << "], called from " << retAddr);
+TypeArtRT::AllocState TypeArtRT::doAlloc(const void* addr, int typeId, size_t count, const void* retAddr) {
+  AllocState status = AllocState::NO_INIT;
+  if (unlikely(!typeDB.isValid(typeId))) {
+    status |= AllocState::UNKNOWN_ID;
+    LOG_ERROR("Allocation of unknown type " << toString(addr, typeId, count, retAddr));
   }
 
   // Calling malloc with size 0 may return a nullptr or some address that can not be written to.
   // In the second case, the allocation is tracked anyway so that onFree() does not report an error.
   // On the other hand, an allocation on address 0x0 with size > 0 is an actual error.
-  if (count == 0) {
+  if (unlikely(count == 0)) {
     Recorder::get().incZeroLengthAddr();
-    LOG_WARNING("Zero-size allocation (id=" << typeId << ") recorded at " << addr << " [" << reg << "], called from "
-                                            << retAddr);
-
+    status |= AllocState::ZERO_COUNT;
+    LOG_WARNING("Zero-size allocation " << toString(addr, typeId, count, retAddr));
     if (addr == nullptr) {
       Recorder::get().incZeroLengthAndNullAddr();
-      return;
+      LOG_ERROR("Zero-size and nullptr allocation " << toString(addr, typeId, count, retAddr));
+      return status | AllocState::NULL_ZERO | AllocState::ADDR_SKIPPED;
     }
-  } else if (addr == nullptr) {
+  } else if (unlikely(addr == nullptr)) {
     Recorder::get().incNullAddr();
-    LOG_ERROR("Nullptr allocation (id=" << typeId << ") recorded at " << addr << " [" << reg << "], called from "
-                                        << retAddr);
-    return;
+    LOG_ERROR("Zero-size allocation " << toString(addr, typeId, count, retAddr));
+    return status | AllocState::NULL_PTR | AllocState::ADDR_SKIPPED;
   }
 
   auto& def = typeMap[addr];
 
-  if (def.typeId == -1) {
-    LOG_TRACE("Alloc " << addr << " " << typeDB.getTypeName(typeId) << " " << typeDB.getTypeSize(typeId) << " " << count
-                       << " " << reg);
-  } else {
+  if (unlikely(def.typeId != -1)) {
     typeart::Recorder::get().incAddrReuse();
-    if (reg == 'G' || reg == 'H') {
-      LOG_ERROR("Already exists (" << retAddr << ", prev=" << def.debug
-                                   << "): " << toString(addr, typeId, count, typeDB.getTypeSize(typeId)));
-      LOG_ERROR("Data in map is: " << toString(addr, def));
-    }
+    status |= AllocState::ADDR_REUSE;
+    LOG_WARNING("Pointer already in map " << toString(addr, typeId, count, retAddr));
+    LOG_WARNING("Overriden data in map " << toString(addr, def));
   }
 
   def.typeId = typeId;
   def.count  = count;
   def.debug  = retAddr;
+
+  return status | AllocState::OK;
 }
 
 void TypeArtRT::onAlloc(const void* addr, int typeId, size_t count, const void* retAddr) {
-  doAlloc(addr, typeId, count, retAddr);
+  const auto status = doAlloc(addr, typeId, count, retAddr);
+  if (status != AllocState::ADDR_SKIPPED) {
+    typeart::Recorder::get().incHeapAlloc(typeId, count);
+  }
+  LOG_TRACE("Alloc " << toString(addr, typeId, count, retAddr) << " " << 'H');
 }
 
 void TypeArtRT::onAllocStack(const void* addr, int typeId, size_t count, const void* retAddr) {
-  doAlloc(addr, typeId, count, retAddr, 'S');
-  stackVars.push_back(addr);
+  const auto status = doAlloc(addr, typeId, count, retAddr);
+  if (status != AllocState::ADDR_SKIPPED) {
+    stackVars.push_back(addr);
+    typeart::Recorder::get().incStackAlloc(typeId, count);
+  }
+  LOG_TRACE("Alloc " << toString(addr, typeId, count, retAddr) << " " << 'S');
 }
 
 void TypeArtRT::onAllocGlobal(const void* addr, int typeId, size_t count, const void* retAddr) {
-  doAlloc(addr, typeId, count, retAddr, 'G');
+  const auto status = doAlloc(addr, typeId, count, retAddr);
+  if (status != AllocState::ADDR_SKIPPED) {
+    typeart::Recorder::get().incGlobalAlloc(typeId, count);
+  }
+  LOG_TRACE("Alloc " << toString(addr, typeId, count, retAddr) << " " << 'G');
 }
 
-template <bool isStack>
-void TypeArtRT::onFree(const void* addr, const void* retAddr) {
-  if (!isStack) {
-    if (addr == nullptr) {
-      LOG_INFO("Recorded free on nullptr, called from " << retAddr);
-      return;
-    }
+template <bool stack>
+TypeArtRT::FreeState TypeArtRT::doFree(const void* addr, const void* retAddr) {
+  if (unlikely(addr == nullptr)) {
+    LOG_ERROR("Free on nullptr "
+              << "(" << retAddr << ")");
+    return FreeState::ADDR_SKIPPED | FreeState::NULL_PTR;
   }
-  auto it = typeMap.find(addr);
-  if (it != typeMap.end()) {
+
+  const auto it = typeMap.find(addr);
+
+  if (likely(it != typeMap.end())) {
     LOG_TRACE("Free " << toString((*it).first, (*it).second));
-    const auto typeId = it->second.typeId;
-    const auto count  = it->second.count;
+
+    if constexpr (!std::is_same_v<Recorder, softcounter::NoneRecorder>) {
+      const auto typeId = it->second.typeId;
+      const auto count  = it->second.count;
+      if (stack) {
+        Recorder::get().incStackFree(typeId, count);
+      } else {
+        Recorder::get().incHeapFree(typeId, count);
+      }
+    }
 
     typeMap.erase(it);
+  } else {
+    LOG_ERROR("Free on unregistered address " << addr << " (" << retAddr << ")");
+    return FreeState::ADDR_SKIPPED | FreeState::UNREG_ADDR;
+  }
 
-    if (!isStack) {
-      Recorder::get().incHeapFree(typeId, count);
-    } else {
-      Recorder::get().incStackFree(typeId, count);
-    }
-  } else if (!isStack) {
-    LOG_ERROR("Free recorded on unregistered address " << addr << ", called from " << retAddr);
+  return FreeState::OK;
+}
+
+void TypeArtRT::onFreeHeap(const void* addr, const void* retAddr) {
+  const auto status = doFree<false>(addr, retAddr);
+  if (FreeState::OK == status) {
+    typeart::Recorder::get().decHeapAlloc();
   }
 }
 
@@ -465,42 +539,39 @@ void TypeArtRT::onLeaveScope(size_t alloca_count, const void* retAddr) {
   const auto cend      = stackVars.cend();
   const auto start_pos = (cend - alloca_count);
   LOG_TRACE("Freeing stack (" << alloca_count << ")  " << std::distance(start_pos, stackVars.cend()))
-  std::for_each(start_pos, cend, [&](const void* addr) { onFree<true>(addr, retAddr); });
+  std::for_each(start_pos, cend, [this, &retAddr](const void* addr) { doFree<true>(addr, retAddr); });
   stackVars.erase(start_pos, cend);
+  typeart::Recorder::get().decStackAlloc(alloca_count);
   LOG_TRACE("Stack after free: " << stackVars.size());
 }
 
 }  // namespace typeart
 
-void __typeart_alloc(void* addr, int typeId, size_t count) {
+void __typeart_alloc(const void* addr, int typeId, size_t count) {
   RUNTIME_GUARD_BEGIN;
   const void* retAddr = __builtin_return_address(0);
   typeart::TypeArtRT::get().onAlloc(addr, typeId, count, retAddr);
-  typeart::Recorder::get().incHeapAlloc(typeId, count);
   RUNTIME_GUARD_END;
 }
 
-void __typeart_alloc_stack(void* addr, int typeId, size_t count) {
+void __typeart_alloc_stack(const void* addr, int typeId, size_t count) {
   RUNTIME_GUARD_BEGIN;
   const void* retAddr = __builtin_return_address(0);
   typeart::TypeArtRT::get().onAllocStack(addr, typeId, count, retAddr);
-  typeart::Recorder::get().incStackAlloc(typeId, count);
   RUNTIME_GUARD_END;
 }
 
-void __typeart_alloc_global(void* addr, int typeId, size_t count) {
+void __typeart_alloc_global(const void* addr, int typeId, size_t count) {
   RUNTIME_GUARD_BEGIN;
   const void* retAddr = __builtin_return_address(0);
   typeart::TypeArtRT::get().onAllocGlobal(addr, typeId, count, retAddr);
-  typeart::Recorder::get().incGlobalAlloc(typeId, count);
   RUNTIME_GUARD_END;
 }
 
-void __typeart_free(void* addr) {
+void __typeart_free(const void* addr) {
   RUNTIME_GUARD_BEGIN;
   const void* retAddr = __builtin_return_address(0);
-  typeart::TypeArtRT::get().onFree<false>(addr, retAddr);
-  typeart::Recorder::get().decHeapAlloc();
+  typeart::TypeArtRT::get().onFreeHeap(addr, retAddr);
   RUNTIME_GUARD_END;
 }
 
@@ -508,7 +579,6 @@ void __typeart_leave_scope(size_t alloca_count) {
   RUNTIME_GUARD_BEGIN;
   const void* retAddr = __builtin_return_address(0);
   typeart::TypeArtRT::get().onLeaveScope(alloca_count, retAddr);
-  typeart::Recorder::get().decStackAlloc(alloca_count);
   RUNTIME_GUARD_END;
 }
 

--- a/runtime/Runtime.cpp
+++ b/runtime/Runtime.cpp
@@ -37,8 +37,6 @@ static bool typeart_rt_scope{false};
 
 namespace typeart {
 
-// std::string TypeArtRT::defaultTypeFileName{"types.yaml"};
-
 template <typename T>
 inline const void* addByteOffset(const void* addr, T offset) {
   return static_cast<const void*>(static_cast<const uint8_t*>(addr) + offset);

--- a/runtime/Runtime.h
+++ b/runtime/Runtime.h
@@ -22,6 +22,7 @@ class TypeArtRT final {
 
   static constexpr const char* defaultTypeFileName = "types.yaml";
 
+ public:
   enum class AllocState : unsigned {
     NO_INIT      = 1 << 0,
     OK           = 1 << 1,
@@ -41,7 +42,6 @@ class TypeArtRT final {
     UNREG_ADDR   = 1 << 4,
   };
 
- public:
   using TypeArtStatus = typeart_status;
 
   static TypeArtRT& get() {

--- a/runtime/Runtime.h
+++ b/runtime/Runtime.h
@@ -2,15 +2,10 @@
 #define RUNTIME_RUNTIME_H_
 
 #include "AccessCounter.h"
+#include "CallbackInterface.h"
 #include "RuntimeData.h"
 #include "RuntimeInterface.h"
 #include "TypeDB.h"
-
-#if !defined(USE_BTREE) && !defined(USE_ABSL)
-#include <map>
-#endif
-
-#include "CallbackInterface.h"
 
 #include <vector>
 
@@ -180,8 +175,6 @@ class TypeArtRT final {
    * Therefore, the caller must either ensure that the given offset is valid or explicitly check for this case.
    */
   size_t getMemberIndex(typeart_struct_layout structInfo, size_t offset) const;
-
-  void printTraceStart() const;
 
   /**
    * Loads the type file created by the LLVM pass.

--- a/runtime/RuntimeData.h
+++ b/runtime/RuntimeData.h
@@ -19,6 +19,10 @@
 #include "absl/container/btree_map.h"
 #endif
 
+#if !defined(USE_BTREE) && !defined(USE_ABSL)
+#include <map>
+#endif
+
 namespace typeart {
 
 using MemAddr = const void*;

--- a/test/runtime/16_inv_struct.cpp
+++ b/test/runtime/16_inv_struct.cpp
@@ -26,15 +26,14 @@ int main() {
     delete ss;  // LLVM does not call _ZdaPv here, but in destructor @_ZN2S1D0Ev
   } catch (...) {
   }
-  
+
   foo();
 
   return 0;
 }
 // main()
-// CHECK: [Trace] Alloc [[POINTER:0x[0-9a-f]+]] struct.S1 16 1 H
-// CHECK: [Trace] Free [[POINTER]]. typeId: [[typeid:2[5-9][0-9]]] (struct.S1).
+// CHECK: [Trace] Alloc [[POINTER:0x[0-9a-f]+]] [[typeid:2[5-9][0-9]]] struct.S1 16 1 ([[ALLOC_FROM:0x[0-9a-f]+]]) H
+// CHECK: [Trace] Free [[POINTER]] [[typeid]] struct.S1 16 1 ([[ALLOC_FROM]])
 // foo()
-// CHECK: [Trace] Alloc [[POINTER:0x[0-9a-f]+]] struct.S1 16 1 H
-// CHECK: [Trace] Free [[POINTER]]. typeId: [[typeid]] (struct.S1).
-
+// CHECK: [Trace] Alloc [[POINTER:0x[0-9a-f]+]] [[typeid:2[5-9][0-9]]] struct.S1 16 1 ([[ALLOC_FROM:0x[0-9a-f]+]]) H
+// CHECK: [Trace] Free [[POINTER]] [[typeid]] struct.S1 16 1 ([[ALLOC_FROM]])


### PR DESCRIPTION
- extract CallbackInterface to header
- enum flags for pointer tracking operation states
- likely unlikely for alloc/dealloc inner functions