### PR TITLE
Fix call to __tycart_cp_recover and forward declare funtions used in macros

### DIFF
--- a/runtime/tycart/TyCartRT.cpp
+++ b/runtime/tycart/TyCartRT.cpp
@@ -375,7 +375,7 @@ void __tycart_init(const char *cfgFile) {
 #endif
 }
 
-void __tycart_cp_recover(const char*name, int version) {
+void __tycart_cp_recover(const char *name, int version) {
 #ifdef WITH_FTI
   #error Currently not implemented with FTI
 #endif

--- a/runtime/tycart/tycart.h
+++ b/runtime/tycart/tycart.h
@@ -50,6 +50,16 @@ void __tycart_register_FTI_t(int typeId);
  */
 void __tycart_register_FTI_t_stub(void* ptr);
 
+/*
+ * Used to recover from a checkpoint
+ */
+void __tycart_cp_recover(const char *name, int version);
+
+/*
+ * Init the different libraries
+ */
+void __tycart_init(const char *cfgFile);
+
 #ifdef __cplusplus
 }
 #endif  // __cplusplus
@@ -118,7 +128,7 @@ void __tycart_register_FTI_t_stub(void* ptr);
 #define TY_unregister_mem(id) __tycart_deregister_mem(id);
 
 // Common API for restart
-#define TY_recover() { __tycart_cp_recover(); }
+#define TY_recover(name, version) { __tycart_cp_recover(name, version); }
 
 //
 // clang-format on


### PR DESCRIPTION
@jplehr 