### PR TITLE
newest ubuntu runner; ci-ext with new ad test

### DIFF
--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -12,10 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install LLVM and Clang
-        run: |
-          sudo apt-get install libllvm10 llvm-10 llvm-10-dev
-          sudo apt-get install clang-10 clang-tidy-10
+      - name: Install LLVM
+        run: sudo apt-get install libllvm10 llvm-10 llvm-10-dev
+
+      - name: Install Clang
+        run: sudo apt-get install clang-10 clang-tidy-10
 
       - name: Install OpenMPI
         run: sudo apt-get install libopenmpi-dev openmpi-bin

--- a/.github/workflows/ext-ci.yml
+++ b/.github/workflows/ext-ci.yml
@@ -2,13 +2,12 @@ name: TypeART-CI-ext
 
 on:
   push:
-    branches:
-      - master
+    branches: [ master, devel ]
   pull_request:
 
 jobs:
   build-and-run-testbench:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, '[ci skip]') || !contains(github.event.head_commit.message, '[ci ext skip]')"
     steps:
       - uses: actions/checkout@v2
@@ -20,11 +19,13 @@ jobs:
           ssh-key: ${{ secrets.AUTH_SSH_CI_EXT }}
           path: test-bench
 
-      - name: Setup LLVM repository
-        run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null | sudo apt-key add -
-          sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main' -y
-          sudo apt-get update -q
+      - name: Checkout AD test-bench
+        uses: actions/checkout@v2
+        with:
+          repository: ahueck/typeart-ad-benchmarks
+          ssh-key: ${{ secrets.AUTH_SSH_CI_EXT_AD }}
+          ref: feat/ci
+          path: ad-test-bench
 
       - name: Install LLVM
         run: sudo apt-get install libllvm10 llvm-10 llvm-10-dev
@@ -72,16 +73,27 @@ jobs:
         working-directory: test-bench/build
         run: ctest -V -R amg2013 -O amg2013_build.log
 
-      - name: Prepare test-bench artifact
-        working-directory: test-bench
+      - name: Setup AD tests
+        working-directory: ad-test-bench
+        run: cmake -B build -DLOG_PATH=${GITHUB_WORKSPACE}/ad-test-bench/artifact
+
+      - name: Run AD lulesh
+        working-directory: ad-test-bench/build
+        run: ctest -V -R lulesh -O ad-lulesh2.0_build.log
+
+      - name: Prepare artifact
         run: |
-          mkdir -p artifact
-          mv build/*_build.log artifact
+          mkdir -p artifact/bench
+          mkdir -p artifact/ad-bench
+          mv test-bench/build/*_build.log artifact/bench
+          mv test-bench/artifact/* artifact/bench
+          mv ad-test-bench/build/*_build.log artifact/ad-bench
+          mv ad-test-bench/artifact/* artifact/ad-bench
 
       - name: Upload test-bench artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
-          name: typeart-bench-archive
-          path: test-bench/artifact
+          name: typeart-ci-ext
+          path: artifact
         
 


### PR DESCRIPTION
- Ubuntu 20.04 runner (has clang/llvm 10 installed by default)
- AD test bench added to CI ext