### PR TITLE
Callback fixes #40 and #41

### DIFF
--- a/lib/runtime/CallbackInterface.h
+++ b/lib/runtime/CallbackInterface.h
@@ -21,7 +21,7 @@ void __typeart_alloc_global(const void* addr, int typeId, size_t count);
 void __typeart_free(const void* addr);
 
 void __typeart_alloc_stack(const void* addr, int typeId, size_t count);
-void __typeart_leave_scope(size_t alloca_count);
+void __typeart_leave_scope(int alloca_count);
 
 #ifdef __cplusplus
 }

--- a/lib/runtime/Runtime.cpp
+++ b/lib/runtime/Runtime.cpp
@@ -534,7 +534,7 @@ void TypeArtRT::onFreeHeap(const void* addr, const void* retAddr) {
   }
 }
 
-void TypeArtRT::onLeaveScope(size_t alloca_count, const void* retAddr) {
+void TypeArtRT::onLeaveScope(int alloca_count, const void* retAddr) {
   if (unlikely(alloca_count > stackVars.size())) {
     LOG_ERROR("Stack is smaller than requested de-allocation count. alloca_count: " << alloca_count
                                                                                     << ". size: " << stackVars.size());
@@ -580,7 +580,7 @@ void __typeart_free(const void* addr) {
   RUNTIME_GUARD_END;
 }
 
-void __typeart_leave_scope(size_t alloca_count) {
+void __typeart_leave_scope(int alloca_count) {
   RUNTIME_GUARD_BEGIN;
   const void* retAddr = __builtin_return_address(0);
   typeart::TypeArtRT::get().onLeaveScope(alloca_count, retAddr);

--- a/lib/runtime/Runtime.h
+++ b/lib/runtime/Runtime.h
@@ -162,7 +162,7 @@ class TypeArtRT final {
 
   void onFreeHeap(const void* addr, const void* retAddr);
 
-  void onLeaveScope(size_t alloca_count, const void* retAddr);
+  void onLeaveScope(int alloca_count, const void* retAddr);
 
  private:
   TypeArtRT();

--- a/test/pass/misc/03_make_mismatch_callback.c
+++ b/test/pass/misc/03_make_mismatch_callback.c
@@ -1,0 +1,10 @@
+// RUN: %c-to-llvm %s | %apply-typeart -typeart-alloca -S 2>&1 | FileCheck %s
+// XFAIL: *
+
+#include <stddef.h>
+void __typeart_leave_scope(size_t alloca_count);
+
+int main(void) {
+  __typeart_leave_scope(0);
+  return 0;
+}

--- a/test/pass/misc/04_make_callback_match.c
+++ b/test/pass/misc/04_make_callback_match.c
@@ -1,0 +1,13 @@
+// RUN: %c-to-llvm %s | %apply-typeart -typeart-alloca -S 2>&1 | FileCheck %s
+
+void __typeart_leave_scope(int alloca_count);
+
+int main(void) {
+  __typeart_leave_scope(0);
+  return 0;
+}
+
+// CHECK:      TypeArtPass [Heap & Stack]
+// CHECK-NEXT: Malloc :   0
+// CHECK-NEXT: Free   :   0
+// CHECK-NEXT: Alloca :   1

--- a/test/pass/misc/05_make_all_callbacks.c
+++ b/test/pass/misc/05_make_all_callbacks.c
@@ -1,0 +1,18 @@
+// RUN: %c-to-llvm %s | %apply-typeart -typeart-alloca -S 2>&1 | FileCheck %s
+
+#include "../../../lib/runtime/CallbackInterface.h"
+
+int main(void) {
+  int count     = 0;
+  int type_id   = 10;
+  size_t extent = 0;
+  void* addr    = NULL;
+  __typeart_alloc(addr, type_id, extent);
+  __typeart_alloc_global(addr, type_id, extent);
+  __typeart_alloc_stack(addr, type_id, extent);
+  __typeart_free(addr);
+  __typeart_leave_scope(count);
+  return 0;
+}
+
+// CHECK:      TypeArtPass [Heap & Stack]


### PR DESCRIPTION
- Allow direct calls to TypeART callback functions, closes #40 
- Fix type mismatch of pass vs. runtime w.r.t. stack alloca counter: i32 vs. i64 (i32 is used now), closes #41 