### PR TITLE
filter: whitelist important functions

### DIFF
--- a/lib/passes/analysis/MemOpData.h
+++ b/lib/passes/analysis/MemOpData.h
@@ -7,6 +7,7 @@
 
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
 
 namespace llvm {
 class CallBase;
@@ -29,6 +30,85 @@ enum class MemOpKind : uint8_t {
   AnyAlloc           = AllocLike | ReallocLike,
   AnyFree            = FreeLike | DeleteLike
 };
+
+struct MemOps {
+  inline llvm::Optional<MemOpKind> kind(llvm::StringRef function) const {
+    if (auto alloc = allocKind(function)) {
+      return alloc;
+    }
+    if (auto dealloc = deallocKind(function)) {
+      return dealloc;
+    }
+    return llvm::None;
+  }
+
+  inline llvm::Optional<MemOpKind> allocKind(llvm::StringRef function) const {
+    if (auto it = alloc_map.find(function); it != std::end(alloc_map)) {
+      return {(*it).second};
+    }
+    return llvm::None;
+  }
+
+  inline llvm::Optional<MemOpKind> deallocKind(llvm::StringRef function) const {
+    if (auto it = dealloc_map.find(function); it != std::end(dealloc_map)) {
+      return {(*it).second};
+    }
+    return llvm::None;
+  }
+
+  const llvm::StringMap<MemOpKind>& allocs() const {
+    return alloc_map;
+  }
+
+  const llvm::StringMap<MemOpKind>& deallocs() const {
+    return dealloc_map;
+  }
+
+ private:
+  //clang-format off
+  const llvm::StringMap<MemOpKind> alloc_map{
+      {"malloc", MemOpKind::MallocLike},
+      {"calloc", MemOpKind::CallocLike},
+      {"realloc", MemOpKind::ReallocLike},
+      {"aligned_alloc", MemOpKind::AlignedAllocLike},
+      {"_Znwm", MemOpKind::NewLike},                                 /*new(unsigned long)*/
+      {"_Znwj", MemOpKind::NewLike},                                 /*new(unsigned int)*/
+      {"_Znam", MemOpKind::NewLike},                                 /*new[](unsigned long)*/
+      {"_Znaj", MemOpKind::NewLike},                                 /*new[](unsigned int)*/
+      {"_ZnwjRKSt9nothrow_t", MemOpKind::MallocLike},                /*new(unsigned int, nothrow)*/
+      {"_ZnwmRKSt9nothrow_t", MemOpKind::MallocLike},                /*new(unsigned long, nothrow)*/
+      {"_ZnajRKSt9nothrow_t", MemOpKind::MallocLike},                /*new[](unsigned int, nothrow)*/
+      {"_ZnamRKSt9nothrow_t", MemOpKind::MallocLike},                /*new[](unsigned long, nothrow)*/
+      {"_ZnwjSt11align_val_t", MemOpKind::NewLike},                  /*new(unsigned int, align_val_t)*/
+      {"_ZnwjSt11align_val_tRKSt9nothrow_t", MemOpKind::MallocLike}, /*new(unsigned int, align_val_t, nothrow)*/
+      {"_ZnwmSt11align_val_t", MemOpKind::NewLike},                  /*new(unsigned long, align_val_t)*/
+      {"_ZnwmSt11align_val_tRKSt9nothrow_t", MemOpKind::MallocLike}, /*new(unsigned long, align_val_t, nothrow)*/
+      {"_ZnajSt11align_val_t", MemOpKind::NewLike},                  /*new[](unsigned int, align_val_t)*/
+      {"_ZnajSt11align_val_tRKSt9nothrow_t", MemOpKind::MallocLike}, /*new[](unsigned int, align_val_t, nothrow)*/
+      {"_ZnamSt11align_val_t", MemOpKind::NewLike},                  /*new[](unsigned long, align_val_t)*/
+      {"_ZnamSt11align_val_tRKSt9nothrow_t", MemOpKind::MallocLike}, /*new[](unsigned long, align_val_t, nothrow)*/
+  };
+
+  const llvm::StringMap<MemOpKind> dealloc_map{
+      {"free", MemOpKind::FreeLike},
+      {"_ZdlPv", MemOpKind::DeleteLike},                              /*delete(void*)*/
+      {"_ZdaPv", MemOpKind::DeleteLike},                              /*delete[](void*)*/
+      {"_ZdlPvj", MemOpKind::DeleteLike},                             /*delete(void*, uint)*/
+      {"_ZdlPvm", MemOpKind::DeleteLike},                             /*delete(void*, ulong)*/
+      {"_ZdlPvRKSt9nothrow_t", MemOpKind::DeleteLike},                /*delete(void*, nothrow)*/
+      {"_ZdaPvj", MemOpKind::DeleteLike},                             /*delete[](void*, uint)*/
+      {"_ZdaPvm", MemOpKind::DeleteLike},                             /*delete[](void*, ulong)*/
+      {"_ZdaPvRKSt9nothrow_t", MemOpKind::DeleteLike},                /*delete[](void*, nothrow)*/
+      {"_ZdaPvSt11align_val_tRKSt9nothrow_t", MemOpKind::DeleteLike}, /* delete(void*, align_val_t, nothrow) */
+      {"_ZdlPvSt11align_val_tRKSt9nothrow_t", MemOpKind::DeleteLike}, /* delete[](void*, align_val_t, nothrow) */
+      {"_ZdlPvjSt11align_val_t", MemOpKind::DeleteLike},              /* delete(void*, unsigned long, align_val_t) */
+      {"_ZdlPvmSt11align_val_t", MemOpKind::DeleteLike},              /* delete(void*, unsigned long, align_val_t) */
+      {"_ZdaPvjSt11align_val_t", MemOpKind::DeleteLike},              /* delete[](void*, unsigned int, align_val_t) */
+      {"_ZdaPvmSt11align_val_t", MemOpKind::DeleteLike},              /* delete[](void*, unsigned long, align_val_t) */
+  };
+  //clang-format off
+};
+
 struct MallocData {
   llvm::CallBase* call{nullptr};
   llvm::BitCastInst* primary{nullptr};  // Non-null if non (void*) cast exists

--- a/lib/passes/analysis/MemOpVisitor.h
+++ b/lib/passes/analysis/MemOpVisitor.h
@@ -22,48 +22,7 @@ struct MemOpVisitor : public llvm::InstVisitor<MemOpVisitor> {
   AllocaDataList allocas;
 
  private:
-  //clang-format off
-  const llvm::StringMap<MemOpKind> alloc_map{
-      {"malloc", MemOpKind::MallocLike},
-      {"calloc", MemOpKind::CallocLike},
-      {"realloc", MemOpKind::ReallocLike},
-      {"aligned_alloc", MemOpKind::AlignedAllocLike},
-      {"_Znwm", MemOpKind::NewLike},                                 /*new(unsigned long)*/
-      {"_Znwj", MemOpKind::NewLike},                                 /*new(unsigned int)*/
-      {"_Znam", MemOpKind::NewLike},                                 /*new[](unsigned long)*/
-      {"_Znaj", MemOpKind::NewLike},                                 /*new[](unsigned int)*/
-      {"_ZnwjRKSt9nothrow_t", MemOpKind::MallocLike},                /*new(unsigned int, nothrow)*/
-      {"_ZnwmRKSt9nothrow_t", MemOpKind::MallocLike},                /*new(unsigned long, nothrow)*/
-      {"_ZnajRKSt9nothrow_t", MemOpKind::MallocLike},                /*new[](unsigned int, nothrow)*/
-      {"_ZnamRKSt9nothrow_t", MemOpKind::MallocLike},                /*new[](unsigned long, nothrow)*/
-      {"_ZnwjSt11align_val_t", MemOpKind::NewLike},                  /*new(unsigned int, align_val_t)*/
-      {"_ZnwjSt11align_val_tRKSt9nothrow_t", MemOpKind::MallocLike}, /*new(unsigned int, align_val_t, nothrow)*/
-      {"_ZnwmSt11align_val_t", MemOpKind::NewLike},                  /*new(unsigned long, align_val_t)*/
-      {"_ZnwmSt11align_val_tRKSt9nothrow_t", MemOpKind::MallocLike}, /*new(unsigned long, align_val_t, nothrow)*/
-      {"_ZnajSt11align_val_t", MemOpKind::NewLike},                  /*new[](unsigned int, align_val_t)*/
-      {"_ZnajSt11align_val_tRKSt9nothrow_t", MemOpKind::MallocLike}, /*new[](unsigned int, align_val_t, nothrow)*/
-      {"_ZnamSt11align_val_t", MemOpKind::NewLike},                  /*new[](unsigned long, align_val_t)*/
-      {"_ZnamSt11align_val_tRKSt9nothrow_t", MemOpKind::MallocLike}, /*new[](unsigned long, align_val_t, nothrow)*/
-  };
-
-  const llvm::StringMap<MemOpKind> dealloc_map{
-      {"free", MemOpKind::FreeLike},
-      {"_ZdlPv", MemOpKind::DeleteLike},                              /*delete(void*)*/
-      {"_ZdaPv", MemOpKind::DeleteLike},                              /*delete[](void*)*/
-      {"_ZdlPvj", MemOpKind::DeleteLike},                             /*delete(void*, uint)*/
-      {"_ZdlPvm", MemOpKind::DeleteLike},                             /*delete(void*, ulong)*/
-      {"_ZdlPvRKSt9nothrow_t", MemOpKind::DeleteLike},                /*delete(void*, nothrow)*/
-      {"_ZdaPvj", MemOpKind::DeleteLike},                             /*delete[](void*, uint)*/
-      {"_ZdaPvm", MemOpKind::DeleteLike},                             /*delete[](void*, ulong)*/
-      {"_ZdaPvRKSt9nothrow_t", MemOpKind::DeleteLike},                /*delete[](void*, nothrow)*/
-      {"_ZdaPvSt11align_val_tRKSt9nothrow_t", MemOpKind::DeleteLike}, /* delete(void*, align_val_t, nothrow) */
-      {"_ZdlPvSt11align_val_tRKSt9nothrow_t", MemOpKind::DeleteLike}, /* delete[](void*, align_val_t, nothrow) */
-      {"_ZdlPvjSt11align_val_t", MemOpKind::DeleteLike},              /* delete(void*, unsigned long, align_val_t) */
-      {"_ZdlPvmSt11align_val_t", MemOpKind::DeleteLike},              /* delete(void*, unsigned long, align_val_t) */
-      {"_ZdaPvjSt11align_val_t", MemOpKind::DeleteLike},              /* delete[](void*, unsigned int, align_val_t) */
-      {"_ZdaPvmSt11align_val_t", MemOpKind::DeleteLike},              /* delete[](void*, unsigned long, align_val_t) */
-  };
-  //clang-format off
+  MemOps mem_operations{};
 
  public:
   void clear();

--- a/lib/passes/filter/Matcher.h
+++ b/lib/passes/filter/Matcher.h
@@ -74,7 +74,7 @@ class FunctionOracleMatcher final : public Matcher {
       if (f_name.startswith("__typeart_")) {
         return MatchResult::ShouldSkip;
       }
-      if (mem_operations.allocKind(f_name) || mem_operations.deallocKind(f_name)) {
+      if (mem_operations.kind(f_name)) {
         return MatchResult::ShouldSkip;
       }
     }

--- a/test/pass/filter/00_ignore_ta_memops.c
+++ b/test/pass/filter/00_ignore_ta_memops.c
@@ -1,0 +1,28 @@
+// clang-format off
+// RUN: %c-to-llvm %s | %apply-typeart -S | %apply-typeart -typeart-alloca -typeart-no-heap=true -call-filter -S 2>&1 | FileCheck %s
+// clang-format on
+
+#include <stdlib.h>
+
+extern double* a;
+
+int main(int argc, char** argv) {
+  int n = argc * 2;
+
+  a = (double*)malloc(sizeof(double) * n);
+
+  free(a);
+
+  return 0;
+}
+
+// CHECK: call void @__typeart_alloc(
+// CHECK: call void @__typeart_free(
+
+// CHECK-NOT: call void @__typeart_leave_scope
+
+// CHECK:      TypeArtPass [Stack]
+// CHECK-NEXT  Malloc :   0
+// CHECK-NEXT  Free   :   0
+// CHECK-NEXT  Alloca :   0
+// CHECK-NEXT  Global :   0


### PR DESCRIPTION
The filter does not consider TypeART callbacks or instrumented memory allocation functions as targets to keep an allocation, closes #53 