### PR TITLE
runtime singleton

### DIFF
--- a/lib/runtime/AllocationTracking.cpp
+++ b/lib/runtime/AllocationTracking.cpp
@@ -231,34 +231,34 @@ llvm::Optional<RuntimeT::MapEntry> AllocationTracker::findBaseAlloc(const void* 
 void __typeart_alloc(const void* addr, int typeId, size_t count) {
   RUNTIME_GUARD_BEGIN;
   const void* retAddr = __builtin_return_address(0);
-  typeart::kRuntimeSystem.allocTracker.onAlloc(addr, typeId, count, retAddr);
+  typeart::RuntimeSystem::get().allocTracker.onAlloc(addr, typeId, count, retAddr);
   RUNTIME_GUARD_END;
 }
 
 void __typeart_alloc_stack(const void* addr, int typeId, size_t count) {
   RUNTIME_GUARD_BEGIN;
   const void* retAddr = __builtin_return_address(0);
-  typeart::kRuntimeSystem.allocTracker.onAllocStack(addr, typeId, count, retAddr);
+  typeart::RuntimeSystem::get().allocTracker.onAllocStack(addr, typeId, count, retAddr);
   RUNTIME_GUARD_END;
 }
 
 void __typeart_alloc_global(const void* addr, int typeId, size_t count) {
   RUNTIME_GUARD_BEGIN;
   const void* retAddr = __builtin_return_address(0);
-  typeart::kRuntimeSystem.allocTracker.onAllocGlobal(addr, typeId, count, retAddr);
+  typeart::RuntimeSystem::get().allocTracker.onAllocGlobal(addr, typeId, count, retAddr);
   RUNTIME_GUARD_END;
 }
 
 void __typeart_free(const void* addr) {
   RUNTIME_GUARD_BEGIN;
   const void* retAddr = __builtin_return_address(0);
-  typeart::kRuntimeSystem.allocTracker.onFreeHeap(addr, retAddr);
+  typeart::RuntimeSystem::get().allocTracker.onFreeHeap(addr, retAddr);
   RUNTIME_GUARD_END;
 }
 
 void __typeart_leave_scope(int alloca_count) {
   RUNTIME_GUARD_BEGIN;
   const void* retAddr = __builtin_return_address(0);
-  typeart::kRuntimeSystem.allocTracker.onLeaveScope(alloca_count, retAddr);
+  typeart::RuntimeSystem::get().allocTracker.onLeaveScope(alloca_count, retAddr);
   RUNTIME_GUARD_END;
 }

--- a/lib/runtime/Runtime.cpp
+++ b/lib/runtime/Runtime.cpp
@@ -17,13 +17,13 @@ namespace debug {
 std::string toString(const void* memAddr, int typeId, size_t count, size_t typeSize, const void* calledFrom) {
   std::string buf;
   llvm::raw_string_ostream s(buf);
-  const auto name = kRuntimeSystem.typeResolution.getTypeName(typeId);
+  const auto name = typeart::RuntimeSystem::get().typeResolution.getTypeName(typeId);
   s << memAddr << " " << typeId << " " << name << " " << typeSize << " " << count << " (" << calledFrom << ")";
   return s.str();
 }
 
 std::string toString(const void* memAddr, int typeId, size_t count, const void* calledFrom) {
-  const auto typeSize = kRuntimeSystem.typeResolution.getTypeSize(typeId);
+  const auto typeSize = typeart::RuntimeSystem::get().typeResolution.getTypeSize(typeId);
   return toString(memAddr, typeId, count, typeSize, calledFrom);
 }
 
@@ -85,10 +85,5 @@ RuntimeSystem::~RuntimeSystem() {
     std::cerr << stream.str();
   }
 }
-
-/**
- * The global runtime instance.
- */
-RuntimeSystem kRuntimeSystem;
 
 }  // namespace typeart

--- a/lib/runtime/Runtime.h
+++ b/lib/runtime/Runtime.h
@@ -32,6 +32,9 @@ struct RuntimeSystem {
   AllocationTracker allocTracker;
 
   static RuntimeSystem& get() {
+    // As opposed to a global variable, a singleton + instantiation during
+    // the first callback/query avoids some problems when
+    // preloading (especially with MUST).
     static RuntimeSystem instance;
     return instance;
   }

--- a/lib/runtime/Runtime.h
+++ b/lib/runtime/Runtime.h
@@ -23,9 +23,6 @@ std::string toString(const void* addr, const PointerInfo& info);
 }  // namespace debug
 
 struct RuntimeSystem {
-  RuntimeSystem();
-  ~RuntimeSystem();
-
  private:
   TypeDB typeDB{};
 
@@ -33,9 +30,16 @@ struct RuntimeSystem {
   Recorder recorder{};
   TypeResolution typeResolution;
   AllocationTracker allocTracker;
-};
 
-extern RuntimeSystem kRuntimeSystem;
+  static RuntimeSystem& get() {
+    static RuntimeSystem instance;
+    return instance;
+  }
+
+ private:
+  RuntimeSystem();
+  ~RuntimeSystem();
+};
 
 }  // namespace typeart
 

--- a/lib/runtime/TypeResolution.cpp
+++ b/lib/runtime/TypeResolution.cpp
@@ -249,31 +249,31 @@ bool TypeResolution::isValidType(int id) const {
  */
 
 typeart_status typeart_get_builtin_type(const void* addr, typeart::BuiltinType* type) {
-  auto alloc = typeart::kRuntimeSystem.allocTracker.findBaseAlloc(addr);
+  auto alloc = typeart::RuntimeSystem::get().allocTracker.findBaseAlloc(addr);
   if (alloc) {
-    return typeart::kRuntimeSystem.typeResolution.getBuiltinInfo(addr, alloc->second, type);
+    return typeart::RuntimeSystem::get().typeResolution.getBuiltinInfo(addr, alloc->second, type);
   }
   return TA_UNKNOWN_ADDRESS;
 }
 
 typeart_status typeart_get_type(const void* addr, int* type, size_t* count) {
-  auto alloc = typeart::kRuntimeSystem.allocTracker.findBaseAlloc(addr);
-  typeart::kRuntimeSystem.recorder.incUsedInRequest(addr);
+  auto alloc = typeart::RuntimeSystem::get().allocTracker.findBaseAlloc(addr);
+  typeart::RuntimeSystem::get().recorder.incUsedInRequest(addr);
   if (alloc) {
-    return typeart::kRuntimeSystem.typeResolution.getTypeInfo(addr, alloc->first, alloc->second, type, count);
+    return typeart::RuntimeSystem::get().typeResolution.getTypeInfo(addr, alloc->first, alloc->second, type, count);
   }
   return TA_UNKNOWN_ADDRESS;
 }
 
 typeart_status typeart_get_containing_type(const void* addr, int* type, size_t* count, const void** base_address,
                                            size_t* offset) {
-  auto alloc = typeart::kRuntimeSystem.allocTracker.findBaseAlloc(addr);
+  auto alloc = typeart::RuntimeSystem::get().allocTracker.findBaseAlloc(addr);
   if (alloc) {
     auto& allocVal = alloc.getValue();
     *type          = alloc->second.typeId;
     *base_address  = alloc->first;
-    return typeart::kRuntimeSystem.typeResolution.getContainingTypeInfo(addr, alloc->first, alloc->second, count,
-                                                                        offset);
+    return typeart::RuntimeSystem::get().typeResolution.getContainingTypeInfo(addr, alloc->first, alloc->second, count,
+                                                                              offset);
   }
   return TA_UNKNOWN_ADDRESS;
 }
@@ -281,13 +281,13 @@ typeart_status typeart_get_containing_type(const void* addr, int* type, size_t* 
 typeart_status typeart_get_subtype(const void* base_addr, size_t offset, typeart_struct_layout container_layout,
                                    int* subtype, const void** subtype_base_addr, size_t* subtype_offset,
                                    size_t* subtype_count) {
-  return typeart::kRuntimeSystem.typeResolution.getSubTypeInfo(base_addr, offset, container_layout, subtype,
-                                                               subtype_base_addr, subtype_offset, subtype_count);
+  return typeart::RuntimeSystem::get().typeResolution.getSubTypeInfo(base_addr, offset, container_layout, subtype,
+                                                                     subtype_base_addr, subtype_offset, subtype_count);
 }
 
 typeart_status typeart_resolve_type(int id, typeart_struct_layout* struct_layout) {
   const typeart::StructTypeInfo* structInfo;
-  typeart_status status = typeart::kRuntimeSystem.typeResolution.getStructInfo(id, &structInfo);
+  typeart_status status = typeart::RuntimeSystem::get().typeResolution.getStructInfo(id, &structInfo);
   if (status == TA_OK) {
     struct_layout->id           = structInfo->id;
     struct_layout->name         = structInfo->name.c_str();
@@ -301,11 +301,11 @@ typeart_status typeart_resolve_type(int id, typeart_struct_layout* struct_layout
 }
 
 const char* typeart_get_type_name(int id) {
-  return typeart::kRuntimeSystem.typeResolution.getTypeName(id).c_str();
+  return typeart::RuntimeSystem::get().typeResolution.getTypeName(id).c_str();
 }
 
 void typeart_get_return_address(const void* addr, const void** retAddr) {
-  auto alloc = typeart::kRuntimeSystem.allocTracker.findBaseAlloc(addr);
+  auto alloc = typeart::RuntimeSystem::get().allocTracker.findBaseAlloc(addr);
 
   if (alloc) {
     *retAddr = alloc.getValue().second.debug;

--- a/test/runtime/12_alloc_multi.c
+++ b/test/runtime/12_alloc_multi.c
@@ -14,7 +14,7 @@ void call() {
 int main(int argc, char** argv) {
   const int n = 42;
   // CHECK: [Trace] TypeART Runtime Trace
-  // CHECK-FILTER: [Trace] TypeART Runtime Trace
+  // CHECK-FILTER-NOT: [Trace] TypeART Runtime Trace
   // CHECK-FILTER-NOT [Trace]
 
   // CHECK: [Trace] Alloc 0x{{.*}} int8 1 42


### PR DESCRIPTION
Changes global variable of RuntimeSystem to a singleton pattern. This avoids problems when preloading the TypeART rt in, e.g., the context of MUST.