### PR TITLE
fix tests w.r.t. ci runner

### DIFF
--- a/lib/runtime/RuntimeData.h
+++ b/lib/runtime/RuntimeData.h
@@ -30,6 +30,7 @@
 #include "safe_ptr.h"
 #endif
 
+#include <cstddef>  // size_t
 #include <vector>
 
 namespace typeart {

--- a/test/pass/new_delete/12_new_aligned.cpp
+++ b/test/pass/new_delete/12_new_aligned.cpp
@@ -17,8 +17,8 @@ C* bar() {
   return new (std::align_val_t(128)) C;
 }
 
-// CHECK: [[POINTER:%[0-9]+]] = call i8* @_ZnamSt11align_val_t(i64 40, i64 64)
+// CHECK: [[POINTER:%[0-9]+]] = call{{.*}} i8* @_ZnamSt11align_val_t(i64 40, i64 64)
 // CHECK-NEXT: call void @__typeart_alloc(i8* [[POINTER]], i32 [[ID:2[5-9][0-9]]], i64 10)
 
-// CHECK: [[POINTER2:%[0-9]+]] = call i8* @_ZnwmSt11align_val_t(i64 4, i64 128)
+// CHECK: [[POINTER2:%[0-9]+]] = call{{.*}} i8* @_ZnwmSt11align_val_t(i64 4, i64 128)
 // CHECK-NEXT: call void @__typeart_alloc(i8* [[POINTER2]], i32 [[ID]], i64 1)


### PR DESCRIPTION
Changes required by updated CI environment (see https://github.com/actions/virtual-environments):
* Add cstddef header for RuntimeData to explicitly pull size_t
* Handle potential noalias in Clang codegen w.r.t. new statement