### PR TITLE
TypeGenerator interface

### DIFF
--- a/lib/passes/TypeARTPass.h
+++ b/lib/passes/TypeARTPass.h
@@ -16,7 +16,6 @@
 #include "instrumentation/Instrumentation.h"
 #include "instrumentation/InstrumentationHelper.h"
 #include "instrumentation/TypeARTFunctions.h"
-#include "typegen/TypeManager.h"
 
 #include "llvm/Pass.h"
 
@@ -31,6 +30,10 @@ class AnalysisUsage;
 class Value;
 class raw_ostream;
 }  // namespace llvm
+
+namespace typeart {
+class TypeGenerator;
+}
 
 namespace typeart::pass {
 
@@ -52,7 +55,7 @@ class TypeArtPass : public llvm::ModulePass {
   TypeArtFunc typeart_free_omp         = typeart_free;
   TypeArtFunc typeart_leave_scope_omp  = typeart_leave_scope;
 
-  TypeManager typeManager;
+  std::unique_ptr<TypeGenerator> typeManager;
   InstrumentationHelper instrumentation_helper;
   TAFunctions functions;
   std::unique_ptr<InstrumentationContext> instrumentation_context;

--- a/lib/passes/filter/FilterBase.h
+++ b/lib/passes/filter/FilterBase.h
@@ -26,7 +26,6 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Intrinsics.h"
 
-#include <TypeARTPass.h>
 #include <iterator>
 #include <type_traits>
 

--- a/lib/passes/instrumentation/MemOpArgCollector.cpp
+++ b/lib/passes/instrumentation/MemOpArgCollector.cpp
@@ -17,7 +17,7 @@
 #include "support/Logger.h"
 #include "support/TypeUtil.h"
 #include "support/Util.h"
-#include "typegen/TypeManager.h"
+#include "typegen/TypeGenerator.h"
 #include "typelib/TypeInterface.h"
 
 #include "llvm/IR/Constants.h"
@@ -39,8 +39,8 @@ using namespace llvm;
 
 namespace typeart {
 
-MemOpArgCollector::MemOpArgCollector(TypeManager& tm, InstrumentationHelper& instr)
-    : ArgumentCollector(), type_m(&tm), instr_helper(&instr) {
+MemOpArgCollector::MemOpArgCollector(TypeGenerator* tm, InstrumentationHelper& instr)
+    : ArgumentCollector(), type_m(tm), instr_helper(&instr) {
 }
 
 HeapArgList MemOpArgCollector::collectHeap(const MallocDataList& mallocs) {

--- a/lib/passes/instrumentation/MemOpArgCollector.h
+++ b/lib/passes/instrumentation/MemOpArgCollector.h
@@ -17,15 +17,15 @@
 #include "analysis/MemOpData.h"
 
 namespace typeart {
-class TypeManager;
+class TypeGenerator;
 class InstrumentationHelper;
 
 class MemOpArgCollector final : public ArgumentCollector {
-  TypeManager* type_m;
+  TypeGenerator* type_m;
   InstrumentationHelper* instr_helper;
 
  public:
-  MemOpArgCollector(TypeManager&, InstrumentationHelper&);
+  MemOpArgCollector(TypeGenerator*, InstrumentationHelper&);
   HeapArgList collectHeap(const MallocDataList& mallocs) override;
   FreeArgList collectFree(const FreeDataList& frees) override;
   StackArgList collectStack(const AllocaDataList& allocs) override;

--- a/lib/passes/typegen/CMakeLists.txt
+++ b/lib/passes/typegen/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
          $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib>
          $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib/passes>
+         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib/typelib>
 )
 
 target_include_directories(${TYPEART_PREFIX}_TypeGenObj SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})

--- a/lib/passes/typegen/TypeGenerator.h
+++ b/lib/passes/typegen/TypeGenerator.h
@@ -13,6 +13,8 @@
 #ifndef TYPEART_TYPEGENERATOR_H
 #define TYPEART_TYPEGENERATOR_H
 
+#include "TypeDatabase.h"
+
 #include <memory>
 #include <string>
 #include <system_error>
@@ -30,6 +32,8 @@ class TypeGenerator {
   [[nodiscard]] virtual int getOrRegisterType(llvm::Type* type, const llvm::DataLayout& layout) = 0;
 
   [[nodiscard]] virtual int getTypeID(llvm::Type* type, const llvm::DataLayout& layout) const = 0;
+
+  [[nodiscard]] virtual const TypeDatabase& getTypeDatabase() const = 0;
 
   [[nodiscard]] virtual std::pair<bool, std::error_code> load() = 0;
 

--- a/lib/passes/typegen/TypeManager.cpp
+++ b/lib/passes/typegen/TypeManager.cpp
@@ -130,6 +130,10 @@ int TypeManager::getOrRegisterVector(llvm::VectorType* type, const llvm::DataLay
 TypeManager::TypeManager(std::string file) : file(std::move(file)), structCount(0) {
 }
 
+const TypeDatabase& TypeManager::getTypeDatabase() const {
+  return typeDB;
+}
+
 std::pair<bool, std::error_code> TypeManager::load() {
   //  TypeIO cio(&typeDB);
   // std::error_code error;

--- a/lib/passes/typegen/TypeManager.h
+++ b/lib/passes/typegen/TypeManager.h
@@ -42,6 +42,7 @@ class TypeManager final : public TypeGenerator {
   [[nodiscard]] std::pair<bool, std::error_code> store() const override;
   [[nodiscard]] int getOrRegisterType(llvm::Type* type, const llvm::DataLayout& dl) override;
   [[nodiscard]] int getTypeID(llvm::Type* type, const llvm::DataLayout& dl) const override;
+  [[nodiscard]] const TypeDatabase& getTypeDatabase() const override;
 
  private:
   [[nodiscard]] int getOrRegisterStruct(llvm::StructType* type, const llvm::DataLayout& dl);


### PR DESCRIPTION
- Replace direct use of TypeManager with TypeGenerator.h interface
- Expose underlying TypeDatabase (of TypeGenerator)