### PR TITLE
Python3

### DIFF
--- a/cmake/ToolchainOptions.cmake
+++ b/cmake/ToolchainOptions.cmake
@@ -129,12 +129,12 @@ set_package_properties(MPI PROPERTIES
 )
 
 if(MPI_INTERCEPT_LIB)
-  find_package(PythonInterp REQUIRED)
+  find_package(Python3 REQUIRED)
 endif()
-set_package_properties(PythonInterp PROPERTIES
+set_package_properties(Python3 PROPERTIES
   TYPE RECOMMENDED
   PURPOSE
-  "The Python interp is used for lit-testing and the MPI interceptor tool code generation."
+  "The Python3 interpreter is used for lit-testing and the MPI interceptor tool code generation."
 )
 
 typeart_find_llvm_progs(TYPEART_CLANG_EXEC "clang;clang-13;clang-12;clang-11;clang-10" "clang")

--- a/cmake/modules/llvm-lit.cmake
+++ b/cmake/modules/llvm-lit.cmake
@@ -1,4 +1,4 @@
-find_package(PythonInterp QUIET)
+find_package(Python3 QUIET)
 
 if(LLVM_EXTERNAL_LIT)
   message(STATUS "External lit path is used")
@@ -11,7 +11,7 @@ if(LLVM_EXTERNAL_LIT)
   if(lit_base_dir)
     set(PATH_TO_LIT ${lit_base_dir}/${PATH_TO_LIT})
   endif()
-  set(LIT_COMMAND_I "${PYTHON_EXECUTABLE};${PATH_TO_LIT}")
+  set(LIT_COMMAND_I "${Python3_EXECUTABLE};${PATH_TO_LIT}")
 endif()
 
 if(NOT LIT_COMMAND_I)

--- a/lib/mpi_interceptor/CMakeLists.txt
+++ b/lib/mpi_interceptor/CMakeLists.txt
@@ -2,7 +2,7 @@ set(LIB_SOURCE ${CMAKE_CURRENT_BINARY_DIR}/mpi_interceptor_rt.c)
 
 add_custom_command(
   OUTPUT ${LIB_SOURCE}
-  COMMAND ${PYTHON_EXECUTABLE} wrap.py mpi_interceptor_tmpl.impl -o
+  COMMAND ${Python3_EXECUTABLE} wrap.py mpi_interceptor_tmpl.impl -o
           ${LIB_SOURCE}
   MAIN_DEPENDENCY mpi_interceptor_tmpl.impl
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
Explicitly find Python3 system installation (and remove deprecated `PythonInterp`)
- Works better with systems having both Python 2 and 3 installed, credit to @ste-lam 