### PR TITLE
MPI logger flag

### DIFF
--- a/lib/runtime/CMakeLists.txt
+++ b/lib/runtime/CMakeLists.txt
@@ -27,7 +27,7 @@ set(RUNTIME_LIB_SOURCES
     Runtime.cpp
     Runtime.h
     ${TYPEART_META_SOURCE}
-    $<$<BOOL:${MPI_LOGGER}>:../support/MPILogger.cpp>
+    $<$<BOOL:${TYPEART_MPI_LOGGER}>:../support/MPILogger.cpp>
 )
 
 add_library(${TYPEART_PREFIX}_Runtime SHARED ${RUNTIME_LIB_SOURCES})
@@ -45,7 +45,7 @@ target_link_libraries(
           typeart::SystemStatic
           LLVMCore
           LLVMSupport
-          $<$<BOOL:${MPI_LOGGER}>:MPI::MPI_CXX>
+          $<$<BOOL:${TYPEART_MPI_LOGGER}>:MPI::MPI_CXX>
           $<$<BOOL:${TYPEART_BTREE}>:google::btree>
           $<$<BOOL:${TYPEART_ABSEIL}>:absl::btree>
           $<$<BOOL:${TYPEART_SAFEPTR}>:sf::pointer>
@@ -66,7 +66,7 @@ target_include_directories(${TYPEART_PREFIX}_Runtime SYSTEM PRIVATE ${LLVM_INCLU
 target_compile_definitions(
   ${TYPEART_PREFIX}_Runtime
   PRIVATE TYPEART_LOG_LEVEL=${TYPEART_LOG_LEVEL_RT}
-          $<$<BOOL:${MPI_LOGGER}>:MPI_LOGGER=1>
+          $<$<BOOL:${TYPEART_MPI_LOGGER}>:TYPEART_MPI_LOGGER=1>
           $<$<BOOL:${TYPEART_SOFTCOUNTERS}>:ENABLE_SOFTCOUNTER=1>
           $<$<BOOL:${TYPEART_BTREE}>:TYPEART_BTREE>
           $<$<BOOL:${TYPEART_ABSEIL}>:TYPEART_ABSEIL>


### PR DESCRIPTION
Use correct MPI logger flag when building runtime.