### PR TITLE
Callback function attributes

### DIFF
--- a/lib/passes/analysis/MemOpVisitor.cpp
+++ b/lib/passes/analysis/MemOpVisitor.cpp
@@ -60,7 +60,7 @@ void MemOpVisitor::collect(llvm::Function& function) {
       data->lifetime_start.insert(lifetime);
     }
   }
-  
+
   for (const auto& alloc : allocas) {
     if (alloc.lifetime_start.size() > 1) {
       LOG_DEBUG("Lifetime: " << alloc.lifetime_start.size());

--- a/lib/passes/instrumentation/TypeARTFunctions.cpp
+++ b/lib/passes/instrumentation/TypeARTFunctions.cpp
@@ -75,6 +75,7 @@ llvm::Function* TAFunctionDeclarator::make_function(IFunc id, llvm::StringRef ba
       if (arg.getType()->isPointerTy()) {
         arg.addAttr(Attribute::NoCapture);
         arg.addAttr(Attribute::ReadOnly);
+        arg.addAttr(Attribute::NoFree);
       }
     }
   };

--- a/lib/passes/instrumentation/TypeARTFunctions.cpp
+++ b/lib/passes/instrumentation/TypeARTFunctions.cpp
@@ -69,6 +69,7 @@ llvm::Function* TAFunctionDeclarator::make_function(IFunc id, llvm::StringRef ba
     function->setDoesNotThrow();
     function->setWillReturn();
     function->setDoesNotFreeMemory();
+    function->setDoesNotRecurse();
 
     for (Argument& arg : function->args()) {
       if (arg.getType()->isPointerTy()) {

--- a/lib/passes/instrumentation/TypeARTFunctions.cpp
+++ b/lib/passes/instrumentation/TypeARTFunctions.cpp
@@ -65,32 +65,37 @@ llvm::Function* TAFunctionDeclarator::make_function(IFunc id, llvm::StringRef ba
   }
 
   auto& c                           = m.getContext();
-  const auto addOptimizerAttributes = [&](llvm::Function* f) {
-    for (Argument& arg : f->args()) {
+  const auto addOptimizerAttributes = [&](llvm::Function* function) {
+    function->setDoesNotThrow();
+    function->setWillReturn();
+    function->setDoesNotFreeMemory();
+
+    for (Argument& arg : function->args()) {
       if (arg.getType()->isPointerTy()) {
         arg.addAttr(Attribute::NoCapture);
         arg.addAttr(Attribute::ReadOnly);
       }
     }
   };
-  const auto setFunctionLinkageExternal = [](llvm::Function* f) {
-    f->setLinkage(GlobalValue::ExternalLinkage);
+  const auto setFunctionLinkageExternal = [](llvm::Function* function) {
+    function->setLinkage(GlobalValue::ExternalLinkage);
     //     f->setLinkage(GlobalValue::ExternalWeakLinkage);
   };
   const auto do_make = [&](auto& name, auto f_type) {
-    const bool has_f = m.getFunction(name) != nullptr;
-    auto fc          = m.getOrInsertFunction(name, f_type);
+    const bool has_func_declared = m.getFunction(name) != nullptr;
+    auto func_in_module          = m.getOrInsertFunction(name, f_type);
 
-    Function* f{nullptr};
-    if (has_f) {
+    Function* function{nullptr};
+    if (has_func_declared) {
       LOG_WARNING("Function " << name << " is already declared in the module.")
-      f = dyn_cast<Function>(fc.getCallee()->stripPointerCasts());
+      function = dyn_cast<Function>(func_in_module.getCallee()->stripPointerCasts());
     } else {
-      f = dyn_cast<Function>(fc.getCallee());
-      setFunctionLinkageExternal(f);
+      function = dyn_cast<Function>(func_in_module.getCallee());
+      setFunctionLinkageExternal(function);
     }
-    addOptimizerAttributes(f);
-    return f;
+
+    addOptimizerAttributes(function);
+    return function;
   };
 
   auto f = do_make(name, FunctionType::get(Type::getVoidTy(c), args, false));

--- a/lib/passes/instrumentation/TypeARTFunctions.cpp
+++ b/lib/passes/instrumentation/TypeARTFunctions.cpp
@@ -67,10 +67,11 @@ llvm::Function* TAFunctionDeclarator::make_function(IFunc id, llvm::StringRef ba
   auto& c                           = m.getContext();
   const auto addOptimizerAttributes = [&](llvm::Function* function) {
     function->setDoesNotThrow();
-    function->setWillReturn();
     function->setDoesNotFreeMemory();
     function->setDoesNotRecurse();
-
+#if LLVM_VERSION_MAJOR >= 12
+    function->setWillReturn();
+#endif
     for (Argument& arg : function->args()) {
       if (arg.getType()->isPointerTy()) {
         arg.addAttr(Attribute::NoCapture);

--- a/lib/passes/instrumentation/TypeARTFunctions.h
+++ b/lib/passes/instrumentation/TypeARTFunctions.h
@@ -68,7 +68,7 @@ class TAFunctionDeclarator {
 
  public:
   TAFunctionDeclarator(llvm::Module& m, InstrumentationHelper& instr, TAFunctions& tafunc);
-  llvm::Function* make_function(IFunc id, llvm::StringRef basename, llvm::ArrayRef<llvm::Type*> args,
+  llvm::Function* make_function(IFunc function, llvm::StringRef basename, llvm::ArrayRef<llvm::Type*> args,
                                 bool with_omp = false, bool fixed_name = true);
   const llvm::StringMap<llvm::Function*>& getFunctionMap() const;
   virtual ~TAFunctionDeclarator() = default;

--- a/test/runtime/24_threads_type_check.cpp
+++ b/test/runtime/24_threads_type_check.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv) {
   free(f2);
 
   // CHECK-TSAN-NOT: ThreadSanitizer
-  
+
   // CHECK: Allocation type detail (heap, stack, global)
   // CHECK: 6   : 3000 ,    0 ,    0 , double
   // CHECK: Free allocation type detail (heap, stack)

--- a/test/runtime/24_threads_type_check.cpp
+++ b/test/runtime/24_threads_type_check.cpp
@@ -56,8 +56,7 @@ int main(int argc, char** argv) {
   free(f2);
 
   // CHECK-TSAN-NOT: ThreadSanitizer
-
-  // CHECK-NOT: Error
+  
   // CHECK: Allocation type detail (heap, stack, global)
   // CHECK: 6   : 3000 ,    0 ,    0 , double
   // CHECK: Free allocation type detail (heap, stack)


### PR DESCRIPTION
- Add callback function attributes such as `nounwind` for better IR gen.
- Add function attribute for void* pointer (`nofree`)