### PR TITLE
Update clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,18 +2,19 @@ Language: Cpp
 # BasedOnStyle:  Google
 AccessModifierOffset: -1
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: true
-AlignEscapedNewlinesLeft: true
+AlignConsecutiveAssignments: AcrossComments
+AlignConsecutiveMacros: AcrossComments
+AlignEscapedNewlines: Left
 AlignOperands: true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: false
-AlwaysBreakTemplateDeclarations: true
+AllowShortFunctionsOnASingleLine: None
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakTemplateDeclarations: Yes
 AlwaysBreakBeforeMultilineStrings: true
 BreakBeforeBinaryOperators: None
 BreakBeforeTernaryOperators: true
@@ -27,7 +28,6 @@ DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: false
 IndentCaseLabels: true
 IndentWrappedFunctionNames: false
-IndentFunctionDeclarationAfterType: false
 MaxEmptyLinesToKeep: 1
 KeepEmptyLinesAtTheStartOfBlocks: false
 NamespaceIndentation: None
@@ -43,7 +43,7 @@ PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
 SpacesBeforeTrailingComments: 2
 Cpp11BracedListStyle: true
-Standard: Cpp11
+Standard: c++17
 IndentWidth: 2
 TabWidth: 2
 UseTab: Never

--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -24,7 +24,7 @@ jobs:
             -a \( -name "*.c" -o -name "*.cpp" -o -name "*.h" \) \
             -not -path "*/lulesh/*" -not -path "*/CallSite.h" \
             -print0 \
-            | xargs -0 clang-format-10 -i
+            | xargs -0 clang-format-12 -i
 
       - name: Format check
         run: |

--- a/demo/01_struct_example.c
+++ b/demo/01_struct_example.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 
 #define MSG_TAG 666
-#define COUNT 5
+#define COUNT   5
 
 // Comment out for heap allocation
 #define USE_STACK

--- a/demo/02_broken_struct_example.c
+++ b/demo/02_broken_struct_example.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 
 #define MSG_TAG 666
-#define COUNT 5
+#define COUNT   5
 
 // Comment out for heap allocation
 //#define USE_STACK

--- a/lib/runtime/AllocationTracking.cpp
+++ b/lib/runtime/AllocationTracking.cpp
@@ -32,12 +32,12 @@
 using namespace btree;
 #endif
 
-#define likely(x) __builtin_expect(!!(x), 1)
+#define likely(x)   __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
 
 #define CONCAT_(x, y) x##y
-#define CONCAT(x, y) CONCAT_(x, y)
-#define GUARDNAME CONCAT(typeart_guard_, __LINE__)
+#define CONCAT(x, y)  CONCAT_(x, y)
+#define GUARDNAME     CONCAT(typeart_guard_, __LINE__)
 
 #define TYPEART_RUNTIME_GUARD     \
   typeart::RTGuard GUARDNAME;     \

--- a/lib/support/Logger.h
+++ b/lib/support/Logger.h
@@ -59,12 +59,12 @@ inline void typeart_log(const std::string& msg) {
   }
 // clang-format on
 
-#define LOG_TRACE(MSG) OO_LOG_LEVEL_MSG_BARE(3, "[Trace]", MSG)
-#define LOG_DEBUG(MSG) OO_LOG_LEVEL_MSG(3, "[Debug]", MSG)
-#define LOG_INFO(MSG) OO_LOG_LEVEL_MSG(2, "[Info]", MSG)
+#define LOG_TRACE(MSG)   OO_LOG_LEVEL_MSG_BARE(3, "[Trace]", MSG)
+#define LOG_DEBUG(MSG)   OO_LOG_LEVEL_MSG(3, "[Debug]", MSG)
+#define LOG_INFO(MSG)    OO_LOG_LEVEL_MSG(2, "[Info]", MSG)
 #define LOG_WARNING(MSG) OO_LOG_LEVEL_MSG(1, "[Warning]", MSG)
-#define LOG_ERROR(MSG) OO_LOG_LEVEL_MSG(1, "[Error]", MSG)
-#define LOG_FATAL(MSG) OO_LOG_LEVEL_MSG(0, "[Fatal]", MSG)
-#define LOG_MSG(MSG) llvm::errs() << MSG << "\n"; /* NOLINT */
+#define LOG_ERROR(MSG)   OO_LOG_LEVEL_MSG(1, "[Error]", MSG)
+#define LOG_FATAL(MSG)   OO_LOG_LEVEL_MSG(0, "[Fatal]", MSG)
+#define LOG_MSG(MSG)     llvm::errs() << MSG << "\n"; /* NOLINT */
 
 #endif /* LIB_LOGGER_H_ */

--- a/test/lulesh/lulesh.h
+++ b/test/lulesh/lulesh.h
@@ -72,40 +72,40 @@ inline real10 FABS(real10 arg) {
 
 // Stuff needed for boundary conditions
 // 2 BCs on each of 6 hexahedral faces (12 bits)
-#define XI_M 0x00007
+#define XI_M      0x00007
 #define XI_M_SYMM 0x00001
 #define XI_M_FREE 0x00002
 #define XI_M_COMM 0x00004
 
-#define XI_P 0x00038
+#define XI_P      0x00038
 #define XI_P_SYMM 0x00008
 #define XI_P_FREE 0x00010
 #define XI_P_COMM 0x00020
 
-#define ETA_M 0x001c0
+#define ETA_M      0x001c0
 #define ETA_M_SYMM 0x00040
 #define ETA_M_FREE 0x00080
 #define ETA_M_COMM 0x00100
 
-#define ETA_P 0x00e00
+#define ETA_P      0x00e00
 #define ETA_P_SYMM 0x00200
 #define ETA_P_FREE 0x00400
 #define ETA_P_COMM 0x00800
 
-#define ZETA_M 0x07000
+#define ZETA_M      0x07000
 #define ZETA_M_SYMM 0x01000
 #define ZETA_M_FREE 0x02000
 #define ZETA_M_COMM 0x04000
 
-#define ZETA_P 0x38000
+#define ZETA_P      0x38000
 #define ZETA_P_SYMM 0x08000
 #define ZETA_P_FREE 0x10000
 #define ZETA_P_COMM 0x20000
 
 // MPI Message Tags
-#define MSG_COMM_SBN 1024
+#define MSG_COMM_SBN     1024
 #define MSG_SYNC_POS_VEL 2048
-#define MSG_MONOQ 3072
+#define MSG_MONOQ        3072
 
 #define MAX_FIELDS_PER_MPI_COMM 6
 

--- a/test/pass/filter/08_amg_box_algebra_mock.c
+++ b/test/pass/filter/08_amg_box_algebra_mock.c
@@ -62,14 +62,14 @@ typedef struct hypre_BoxArrayArray_struct {
 
 #define hypre_CCBoxOffsetDistance(box, index) 0
 
-#define hypre_BoxArrayBoxes(box_array) ((box_array)->boxes)
-#define hypre_BoxArrayBox(box_array, i) &((box_array)->boxes[(i)])
-#define hypre_BoxArraySize(box_array) ((box_array)->size)
+#define hypre_BoxArrayBoxes(box_array)     ((box_array)->boxes)
+#define hypre_BoxArrayBox(box_array, i)    &((box_array)->boxes[(i)])
+#define hypre_BoxArraySize(box_array)      ((box_array)->size)
 #define hypre_BoxArrayAllocSize(box_array) ((box_array)->alloc_size)
 
-#define hypre_BoxArrayArrayBoxArrays(box_array_array) ((box_array_array)->box_arrays)
+#define hypre_BoxArrayArrayBoxArrays(box_array_array)   ((box_array_array)->box_arrays)
 #define hypre_BoxArrayArrayBoxArray(box_array_array, i) ((box_array_array)->box_arrays[(i)])
-#define hypre_BoxArrayArraySize(box_array_array) ((box_array_array)->size)
+#define hypre_BoxArrayArraySize(box_array_array)        ((box_array_array)->size)
 
 extern int hypre_UnionBoxes(hypre_BoxArray* boxes);
 extern hypre_BoxArrayArray* hypre_BoxArrayArrayCreate(int);

--- a/test/pass/filter/09_milc_gauge_stuff_mock.c
+++ b/test/pass/filter/09_milc_gauge_stuff_mock.c
@@ -14,10 +14,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define XUP 0
-#define YUP 1
-#define ZUP 2
-#define TUP 3
+#define XUP   0
+#define YUP   1
+#define ZUP   2
+#define TUP   3
 #define TDOWN 4
 #define ZDOWN 5
 #define YDOWN 6
@@ -26,12 +26,12 @@
 #define NODIR -1
 
 #define OPP_DIR(dir) (7 - (dir))
-#define NDIRS 8
+#define NDIRS        8
 
-#define NREPS 1
-#define NLOOP 3
+#define NREPS      1
+#define NLOOP      3
 #define MAX_LENGTH 6
-#define MAX_NUM 16
+#define MAX_NUM    16
 
 extern char gauge_action_description[128];
 int gauge_action_nloops = NLOOP;

--- a/test/pass/filter/16_omp_reduction.c
+++ b/test/pass/filter/16_omp_reduction.c
@@ -26,7 +26,7 @@ void foo() {
   // check-inst: [[POINTER:%[0-9a-z]+]] = bitcast float* %loc to i8*
   // check-inst: call void @__typeart_alloc_stack(i8* [[POINTER]], i32 5, i64 1)
   // check-inst-not: __typeart_alloc_stack_omp
-  float loc = sum(array, n);
+  float loc      = sum(array, n);
   MPI_send((void*)&loc);
 }
 

--- a/test/runtime/10_vector_fill_demo.c
+++ b/test/runtime/10_vector_fill_demo.c
@@ -36,18 +36,18 @@ int fill_vector(void* values, int count, vector* v) {
 }
 
 int main(int argc, char** argv) {
-  const int n = 3;
+  const int n      = 3;
   // CHECK: [Trace] TypeART Runtime Trace
   // CHECK: [Trace] Alloc 0x{{.*}} int32 4 3
-  int int_vals[3] = {1, 2, 3};
+  int int_vals[3]  = {1, 2, 3};
   // CHECK: [Trace] Alloc 0x{{.*}} double 8 3
   double d_vals[3] = {1, 2, 3};
   // CHECK: [Trace] Alloc 0x{{.*}} float 4 3
-  float f_vals[3] = {1, 2, 3};
+  float f_vals[3]  = {1, 2, 3};
   // CHECK: [Trace] Alloc 0x{{.*}} double 8 3
-  vector v = alloc_vector(n);
+  vector v         = alloc_vector(n);
   // CHECK: [Trace] Alloc 0x{{.*}} double 8 3
-  vector w = alloc_vector(n);
+  vector w         = alloc_vector(n);
   // CHECK: Success
   fill_vector(w.vals, n, &v);
   // CHECK: Failure

--- a/test/runtime/45_default_types.c
+++ b/test/runtime/45_default_types.c
@@ -7,7 +7,7 @@ int main(int argc, char** argv) {
   // CHECK: [Trace] TypeART Runtime Trace
   // CHECK: [Warning]{{.*}}No type file with default name
   // CHECK: [Trace] Alloc 0x{{.*}} int8 1 42
-  char* a = malloc(n * sizeof(char));
+  char* a     = malloc(n * sizeof(char));
   // CHECK: [Trace] Free 0x{{.*}}
   free(a);
 }


### PR DESCRIPTION
Depent on clang-format-12 going forward.

Note: This makes clang-format-10 (and maybe 11) error out, due to unsupported values.