### PR TITLE
Disable CI AD LLVM-12 safeptr run

### DIFF
--- a/.github/workflows/ext-ci.yml
+++ b/.github/workflows/ext-ci.yml
@@ -101,10 +101,6 @@ jobs:
         preset:
           - name: release-counter
           - name: release-unsafe-counter
-        include:
-          - llvm-version: 12
-            preset:
-              name: release-safeptr-counter
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
It appears to be broken still, see #64 