### PR TITLE
Emit base IR with wrapper

### DIFF
--- a/scripts/typeart-wrapper.in
+++ b/scripts/typeart-wrapper.in
@@ -311,16 +311,26 @@ function typeart_main_link_fn() {
   $typeart_compiler ${typeart_includes} ${typeart_ldflags} ${typeart_san_flags} $@
 }
 
-
 # shellcheck disable=SC2068
-function typeart_opt_redirect_fn() {
+function typeart_redirect_fn() {
   # First argument of $@ must be "redirect file name"
   # Rest are the std arguments for opt
   if [ -z ${typeart_wrapper_emit_ir} ] || [ ${typeart_wrapper_emit_ir} -eq 0 ]; then
-    $typeart_opt_tool ${@:2}
+    $typeart_command_exe ${@:2}
   else
-    $typeart_opt_tool -S ${@:2} | tee "${@:1:1}"
+    # FIXME with clang, duplicate "-S"
+    $typeart_command_exe -S ${@:2} | tee "${@:1:1}"
   fi
+}
+
+function typeart_opt_fn() {
+  local typeart_command_exe="$typeart_opt_tool"
+  typeart_redirect_fn "$@"
+}
+
+function typeart_compiler_fn() {
+  local typeart_command_exe="$typeart_compiler"
+  typeart_redirect_fn "$@"
 }
 
 function typeart_main_compile_fn() {
@@ -348,11 +358,11 @@ function typeart_main_compile_fn() {
   fi
 
   # shellcheck disable=SC2086
-  $typeart_compiler ${typeart_wrapper_more_args} ${typeart_includes} ${typeart_san_flags} \
+  typeart_compiler_fn "${out_basename}"_base.ll ${typeart_wrapper_more_args} ${typeart_includes} ${typeart_san_flags} \
     ${typeart_to_llvm_flags} ${typeart_to_llvm_more_flags} "${typeart_source_file}" -o - |
-    typeart_opt_redirect_fn "${out_basename}"_heap.ll ${typeart_plugin} ${typeart_heap_mode_args} ${typeart_cmdline_args_heap}  |
-    typeart_opt_redirect_fn "${out_basename}"_opt.ll ${typeart_optimize} |
-    typeart_opt_redirect_fn "${out_basename}"_stack.ll ${typeart_plugin} ${typeart_stack_mode_args} ${typeart_cmdline_args_stack} |
+    typeart_opt_fn "${out_basename}"_heap.ll ${typeart_plugin} ${typeart_heap_mode_args} ${typeart_cmdline_args_heap}  |
+    typeart_opt_fn "${out_basename}"_opt.ll ${typeart_optimize} |
+    typeart_opt_fn "${out_basename}"_stack.ll ${typeart_plugin} ${typeart_stack_mode_args} ${typeart_cmdline_args_stack} |
     $typeart_llc_tool -x=ir ${llc_flags} -o "${out_file}"
 }
 

--- a/scripts/typeart_ir_compare.py
+++ b/scripts/typeart_ir_compare.py
@@ -24,7 +24,7 @@ parser.add_argument('source_file')
 parser.add_argument('-d', '--diff-viewer', default='meld', help='Diff viewer')
 parser.add_argument('-a', '--wrapper-a', help='TypeART wrapper path A')
 parser.add_argument('-b', '--wrapper-b', help='TypeART wrapper path B')
-parser.add_argument('-m', '--mode', default='heap', choices=['heap', 'opt', 'stack'],
+parser.add_argument('-m', '--mode', default='heap', choices=['base', 'heap', 'opt', 'stack'],
                     help='View diff of specified phase')
 parser.add_argument('-s', '--skip-viewer', action='store_const', const=True, default=False,
                     help='Only generate IR files, no diff viewer')

--- a/test/script/12_ir_viewer.sh
+++ b/test/script/12_ir_viewer.sh
@@ -17,6 +17,8 @@ cd "$3"
 # CHECK: 0
 # CHECK: 0
 # CHECK: 0
+# CHECK: 0
+exists 12_ir_viewer_target_base.ll
 exists 12_ir_viewer_target_heap.ll
 exists 12_ir_viewer_target_opt.ll
 exists 12_ir_viewer_target_stack.ll
@@ -26,6 +28,8 @@ python $1 -s -w "$2" 12_ir_viewer_target.c -- -g
 # CHECK: 1
 # CHECK: 1
 # CHECK: 1
+# CHECK: 1
+exists 12_ir_viewer_target_base.ll
 exists 12_ir_viewer_target_heap.ll
 exists 12_ir_viewer_target_opt.ll
 exists 12_ir_viewer_target_stack.ll
@@ -36,6 +40,8 @@ python $1 -c 12_ir_viewer_target.c
 # CHECK: 0
 # CHECK: 0
 # CHECK: 0
+# CHECK: 0
+exists 12_ir_viewer_target_base.ll
 exists 12_ir_viewer_target_heap.ll
 exists 12_ir_viewer_target_opt.ll
 exists 12_ir_viewer_target_stack.ll

--- a/test/script/13_ir_compare.sh
+++ b/test/script/13_ir_compare.sh
@@ -39,3 +39,11 @@ exists 12_ir_viewer_target_stack.ll-a
 exists 12_ir_viewer_target_stack.ll-b
 
 rm 12_ir_viewer_target_stack.ll-a 12_ir_viewer_target_stack.ll-b
+
+python $1 -s -m base -a "$2" -b "$3" 12_ir_viewer_target.c -- -g
+# CHECK: 1
+# CHECK: 1
+exists 12_ir_viewer_target_base.ll-a
+exists 12_ir_viewer_target_base.ll-b
+
+rm 12_ir_viewer_target_base.ll-a 12_ir_viewer_target_base.ll-b


### PR DESCRIPTION
- Emit clang compiler IR with wrapper (base IR)
- Modify python scripts to handle base IR
  - viewer: views up to three files (base skipped by default)