### PR TITLE
Wrapper emit-llvm

### DIFF
--- a/scripts/typeart-wrapper.in
+++ b/scripts/typeart-wrapper.in
@@ -83,9 +83,8 @@ function typeart_global_init_fn() {
   typeart_global_env_var_init_fn
 
   readonly typeart_to_llvm_flags="-O1 -Xclang -disable-llvm-passes -c -emit-llvm"
-  if [ -z ${typeart_wrapper_emit_ir} ] || [ ${typeart_wrapper_emit_ir} -eq 0 ]; then
-    typeart_to_llvm_more_flags=""
-  else
+  typeart_to_llvm_more_flags=""
+  if [ ${typeart_wrapper_emit_ir} == 1 ]; then
     typeart_to_llvm_more_flags="-fno-discard-value-names"
   fi
 }
@@ -175,7 +174,7 @@ function typeart_try_extract_object_fn() {
   esac
 }
 
-function handle_object_flag() {
+function typeart_handle_object_flag() {
   if [ -n "$2" ]; then
     typeart_try_extract_object_fn "$2" 2
   else
@@ -211,13 +210,11 @@ function typeart_parse_typeart_cmd_line_fn() {
       shift
       ;;
     *) # preserve other arguments
-      typeart_other_args="$typeart_other_args $1"
+      typeart_other_args+=" $1"
       shift
       ;;
     esac
   done
-  # set other positional arguments in their proper place
-  set -- "typeart_other_args"
 }
 
 # shellcheck disable=SC2034
@@ -241,7 +238,7 @@ function typeart_parse_cmd_line_fn() {
     case "$1" in
     -O?)
       typeart_optimize=$1
-      shift
+      shift 1
       ;;
     -MT)
       if [ -n "$2" ]; then
@@ -254,6 +251,9 @@ function typeart_parse_cmd_line_fn() {
       ;;
     -S)
       typeart_to_asm=1
+      shift 1
+      ;;
+    -c)
       shift 1
       ;;
     *.s | *.bc | *.ll)
@@ -269,24 +269,24 @@ function typeart_parse_cmd_line_fn() {
       if [ "$typeart_linking" == 1 ]; then
         typeart_handle_binary_fn "$1" "$2"
       else
-        handle_object_flag "$1" "$2"
+        typeart_handle_object_flag "$1" "$2"
       fi
       shift $?
       ;;
     *.o)
       if [ "$typeart_linking" == 0 ]; then
-        handle_object_flag "$1"
+        typeart_handle_object_flag "$1"
         shift $?
       else
         # when typeart_linking, we don't care about object files
-        typeart_wrapper_more_args="$typeart_wrapper_more_args $1"
+        typeart_wrapper_more_args+=" $1"
         shift 1
       fi
       ;;
     -fPIC)
       # llc requires special flag
       typeart_found_fpic=1
-      typeart_wrapper_more_args="$typeart_wrapper_more_args $1"
+      typeart_wrapper_more_args+=" $1"
       shift 1
       ;;
     -emit-llvm)
@@ -294,13 +294,11 @@ function typeart_parse_cmd_line_fn() {
       shift 1
       ;;
     *) # preserve other arguments
-      typeart_wrapper_more_args="$typeart_wrapper_more_args $1"
-      shift
+      typeart_wrapper_more_args+=" $1"
+      shift 1
       ;;
     esac
   done
-  # set other positional arguments in their proper place
-  eval set -- "typeart_wrapper_more_args"
 
   if [ -z "${typeart_optimize}" ]; then
     typeart_optimize=-O0
@@ -340,29 +338,6 @@ function typeart_compiler_fn() {
 
 # shellcheck disable=SC2120
 function typeart_tu_out_fn() {
-  if [ "$typeart_emit_llvm" == 1 ] && [ "$typeart_to_asm" == 1 ]; then
-    local typeart_command_exe="${typeart_opt_tool} -S"
-  elif [ "$typeart_emit_llvm" == 1 ]; then
-    local typeart_command_exe="${typeart_opt_tool} -f"
-  else
-    local typeart_command_exe="${typeart_llc_tool} -x=ir ${llc_flags}"
-  fi
-
-  if [ "${typeart_to_stdout}" == 0 ]; then
-    local typeart_command_exe="${typeart_command_exe} -o ${out_file}"
-  fi
-
-  $typeart_command_exe "$@"
-}
-
-function typeart_main_compile_fn() {
-
-  local out_basename="${typeart_source_file%.*}"
-  if [ -z "${typeart_object_file}" ]; then
-    # if no object file is specified, use filename(typeart_source_file).o
-    typeart_object_file="${out_basename}".o
-  fi
-
   local out_file="${typeart_object_file}"
   local llc_flags="--filetype=obj"
 
@@ -385,9 +360,30 @@ function typeart_main_compile_fn() {
   fi
 
   if [ "$typeart_found_fpic" == 1 ]; then
-    local llc_flags="$llc_flags --relocation-model=pic"
+    local llc_flags+=" --relocation-model=pic"
   fi
 
+  if [ "$typeart_emit_llvm" == 1 ] && [ "$typeart_to_asm" == 1 ]; then
+    local typeart_command_exe="${typeart_opt_tool} -S"
+  elif [ "$typeart_emit_llvm" == 1 ]; then
+    local typeart_command_exe="${typeart_opt_tool} -f"
+  else
+    local typeart_command_exe="${typeart_llc_tool} -x=ir ${llc_flags}"
+  fi
+
+  if [ "${typeart_to_stdout}" == 0 ]; then
+    local typeart_command_exe+=" -o ${out_file}"
+  fi
+
+  $typeart_command_exe "$@"
+}
+
+function typeart_main_compile_fn() {
+  local -r out_basename="${typeart_source_file%.*}"
+  if [ -z "${typeart_object_file}" ]; then
+    # if no object file is specified, use filename(typeart_source_file).o
+    typeart_object_file="${out_basename}".o
+  fi
   # shellcheck disable=SC2086
   typeart_compiler_fn "${out_basename}"_base.ll ${typeart_wrapper_more_args} ${typeart_includes} ${typeart_san_flags} \
     ${typeart_to_llvm_flags} ${typeart_to_llvm_more_flags} "${typeart_source_file}" -o - |

--- a/scripts/typeart-wrapper.in
+++ b/scripts/typeart-wrapper.in
@@ -165,6 +165,10 @@ function typeart_try_extract_object_fn() {
     typeart_found_obj_file=1
     return "$shift_val"
     ;;
+  -)
+    typeart_to_stdout=1
+    return "$shift_val"
+    ;;
   *)
     return 1
     ;;
@@ -231,6 +235,7 @@ function typeart_parse_cmd_line_fn() {
   typeart_wrapper_more_args=""
   typeart_optimize=""
   typeart_emit_llvm=0
+  typeart_to_stdout=0
 
   while (("$#")); do
     case "$1" in
@@ -336,17 +341,22 @@ function typeart_compiler_fn() {
 # shellcheck disable=SC2120
 function typeart_tu_out_fn() {
   if [ "$typeart_emit_llvm" == 1 ] && [ "$typeart_to_asm" == 1 ]; then
-    local typeart_command_exe="${typeart_opt_tool} -S -o ${out_file}"
+    local typeart_command_exe="${typeart_opt_tool} -S"
   elif [ "$typeart_emit_llvm" == 1 ]; then
-    local typeart_command_exe="${typeart_opt_tool} -f -o ${out_file}"
+    local typeart_command_exe="${typeart_opt_tool} -f"
   else
-    local typeart_command_exe="${typeart_llc_tool} -x=ir ${llc_flags} -o ${out_file}"
+    local typeart_command_exe="${typeart_llc_tool} -x=ir ${llc_flags}"
   fi
+
+  if [ "${typeart_to_stdout}" == 0 ]; then
+    local typeart_command_exe="${typeart_command_exe} -o ${out_file}"
+  fi
+
   $typeart_command_exe "$@"
 }
 
 function typeart_main_compile_fn() {
-  set -x
+
   local out_basename="${typeart_source_file%.*}"
   if [ -z "${typeart_object_file}" ]; then
     # if no object file is specified, use filename(typeart_source_file).o

--- a/scripts/typeart-wrapper.in
+++ b/scripts/typeart-wrapper.in
@@ -82,7 +82,7 @@ function typeart_global_init_fn() {
   typeart_cmdline_args_stack=""
   typeart_global_env_var_init_fn
 
-  readonly typeart_to_llvm_flags="-O1 -Xclang -disable-llvm-passes -S -emit-llvm"
+  readonly typeart_to_llvm_flags="-O1 -Xclang -disable-llvm-passes -c -emit-llvm"
   if [ -z ${typeart_wrapper_emit_ir} ] || [ ${typeart_wrapper_emit_ir} -eq 0 ]; then
     typeart_to_llvm_more_flags=""
   else
@@ -94,7 +94,7 @@ function typeart_is_typeart_linking_fn() {
   local arg=""
   for arg in "$@"; do
     case "$arg" in
-    -c | -S | -E)
+    -c | -S | -E | -emit-llvm)
       return 0
     ;;
     esac
@@ -230,6 +230,7 @@ function typeart_parse_cmd_line_fn() {
   typeart_asm_file=""
   typeart_wrapper_more_args=""
   typeart_optimize=""
+  typeart_emit_llvm=0
 
   while (("$#")); do
     case "$1" in
@@ -246,15 +247,11 @@ function typeart_parse_cmd_line_fn() {
         shift 1
       fi
       ;;
-    -c | -S)
-      # -S compile to asm
-      if [ "$1" == "-S" ]; then
-        typeart_to_asm=1
-      fi
-      typeart_handle_source_flag_fn "$1" "$2"
-      shift $?
+    -S)
+      typeart_to_asm=1
+      shift 1
       ;;
-    *.s)
+    *.s | *.bc | *.ll)
       typeart_asm_file="$1"
       shift 1
       ;;
@@ -278,14 +275,18 @@ function typeart_parse_cmd_line_fn() {
       else
         # when typeart_linking, we don't care about object files
         typeart_wrapper_more_args="$typeart_wrapper_more_args $1"
-        shift
+        shift 1
       fi
       ;;
     -fPIC)
       # llc requires special flag
       typeart_found_fpic=1
       typeart_wrapper_more_args="$typeart_wrapper_more_args $1"
-      shift
+      shift 1
+      ;;
+    -emit-llvm)
+      typeart_emit_llvm=1
+      shift 1
       ;;
     *) # preserve other arguments
       typeart_wrapper_more_args="$typeart_wrapper_more_args $1"
@@ -318,7 +319,6 @@ function typeart_redirect_fn() {
   if [ -z ${typeart_wrapper_emit_ir} ] || [ ${typeart_wrapper_emit_ir} -eq 0 ]; then
     $typeart_command_exe ${@:2}
   else
-    # FIXME with clang, duplicate "-S"
     $typeart_command_exe -S ${@:2} | tee "${@:1:1}"
   fi
 }
@@ -333,23 +333,44 @@ function typeart_compiler_fn() {
   typeart_redirect_fn "$@"
 }
 
+# shellcheck disable=SC2120
+function typeart_tu_out_fn() {
+  if [ "$typeart_emit_llvm" == 1 ] && [ "$typeart_to_asm" == 1 ]; then
+    local typeart_command_exe="${typeart_opt_tool} -S -o ${out_file}"
+  elif [ "$typeart_emit_llvm" == 1 ]; then
+    local typeart_command_exe="${typeart_opt_tool} -f -o ${out_file}"
+  else
+    local typeart_command_exe="${typeart_llc_tool} -x=ir ${llc_flags} -o ${out_file}"
+  fi
+  $typeart_command_exe "$@"
+}
+
 function typeart_main_compile_fn() {
+  set -x
+  local out_basename="${typeart_source_file%.*}"
   if [ -z "${typeart_object_file}" ]; then
     # if no object file is specified, use filename(typeart_source_file).o
-    typeart_object_file="${typeart_source_file%.*}".o
+    typeart_object_file="${out_basename}".o
   fi
 
-  if [ "$typeart_to_asm" == 1 ] && [ -z "${typeart_asm_file}" ]; then
-    # if no asm file is specified, use filename(typeart_source_file).s
-    local typeart_asm_file="${typeart_source_file%.*}".s
-  fi
-
-  local out_basename="${typeart_source_file%.*}"
   local out_file="${typeart_object_file}"
   local llc_flags="--filetype=obj"
 
   if [ "$typeart_to_asm" == 1 ]; then
     local llc_flags="--filetype=asm"
+  fi
+
+  if [ -z "${typeart_asm_file}" ]; then
+    if [ "$typeart_emit_llvm" == 1 ] && [ "$typeart_to_asm" == 1 ]; then
+      local typeart_asm_file="${out_basename}".ll
+    elif [ "$typeart_emit_llvm" == 1 ]; then
+      local typeart_asm_file="${out_basename}".bc
+    elif [ "$typeart_to_asm" == 1 ]; then
+      local typeart_asm_file="${out_basename}".s
+    fi
+  fi
+
+  if [ "$typeart_emit_llvm" == 1 ] || [ "$typeart_to_asm" == 1 ]; then
     local out_file="${typeart_asm_file}"
   fi
 
@@ -360,10 +381,10 @@ function typeart_main_compile_fn() {
   # shellcheck disable=SC2086
   typeart_compiler_fn "${out_basename}"_base.ll ${typeart_wrapper_more_args} ${typeart_includes} ${typeart_san_flags} \
     ${typeart_to_llvm_flags} ${typeart_to_llvm_more_flags} "${typeart_source_file}" -o - |
-    typeart_opt_fn "${out_basename}"_heap.ll ${typeart_plugin} ${typeart_heap_mode_args} ${typeart_cmdline_args_heap}  |
+    typeart_opt_fn "${out_basename}"_heap.ll ${typeart_plugin} ${typeart_heap_mode_args} ${typeart_cmdline_args_heap} |
     typeart_opt_fn "${out_basename}"_opt.ll ${typeart_optimize} |
     typeart_opt_fn "${out_basename}"_stack.ll ${typeart_plugin} ${typeart_stack_mode_args} ${typeart_cmdline_args_stack} |
-    $typeart_llc_tool -x=ir ${llc_flags} -o "${out_file}"
+    typeart_tu_out_fn
 }
 
 function typeart_main_driver_fn() {

--- a/test/script/14_wrapper_ll.c
+++ b/test/script/14_wrapper_ll.c
@@ -10,6 +10,10 @@
 // RUN: TYPEART_WRAPPER=OFF %wrapper-cc -c -emit-llvm -O1 %s -o %s-van.bc
 // RUN: cat %s-van.bc 2>&1 | %opt -S | %filecheck %s --check-prefixes vanilla-CHECK
 
+// RUN: %wrapper-cc -S -emit-llvm -O1 %s -o - | %filecheck %s
+
+// RUN: %wrapper-cc -emit-llvm -O1 %s -o - | %opt -S | %filecheck %s
+
 #include <stdlib.h>
 
 int main(int argc, char** argv) {

--- a/test/script/14_wrapper_ll.c
+++ b/test/script/14_wrapper_ll.c
@@ -1,0 +1,21 @@
+// RUN: %wrapper-cc -S -emit-llvm -O1 %s -o %s.ll
+// RUN: cat %s.ll 2>&1 | %filecheck %s
+
+// RUN: %wrapper-cc -emit-llvm -O1 %s -o %s.bc
+// RUN: cat %s.bc 2>&1 | %opt -S | %filecheck %s
+
+// RUN: TYPEART_WRAPPER=OFF %wrapper-cc -S -emit-llvm -O1 %s -o %s-van.ll
+// RUN: cat %s-van.ll 2>&1 | %filecheck %s --check-prefixes vanilla-CHECK
+
+// RUN: TYPEART_WRAPPER=OFF %wrapper-cc -c -emit-llvm -O1 %s -o %s-van.bc
+// RUN: cat %s-van.bc 2>&1 | %opt -S | %filecheck %s --check-prefixes vanilla-CHECK
+
+#include <stdlib.h>
+
+int main(int argc, char** argv) {
+  int* p = malloc(argc * sizeof(int));
+  return 0;
+}
+
+// CHECK: __typeart_alloc
+// vanilla-CHECK-NOT: __typeart_alloc


### PR DESCRIPTION
Wrapper handles flags:
- `-S` : To asm code
- `-emit-llvm`: To LLVM bitcode
- `-emit-llvm -S`: To LLVM IR
- `-o -`: Emit to console/stdout

As suggested by @ste-lam. 
This will help with debugging and coupling with other tools relying on typeart (IR) output.