### PR TITLE
Environment Variable Configuration

### DIFF
--- a/lib/passes/CMakeLists.txt
+++ b/lib/passes/CMakeLists.txt
@@ -12,6 +12,7 @@ set(PASS_SOURCES
   instrumentation/MemOpInstrumentation.cpp
   instrumentation/Instrumentation.cpp
   ../support/FileConfiguration.cpp
+  ../support/TypeARTOptions.cpp
   TypeARTConfiguration.cpp
 )
 

--- a/lib/passes/CMakeLists.txt
+++ b/lib/passes/CMakeLists.txt
@@ -1,19 +1,18 @@
 add_subdirectory(typegen)
 add_subdirectory(filter)
 add_subdirectory(analysis)
+add_subdirectory(configuration)
 
 set(PASS_SOURCES
   TypeARTPass.cpp
-  Commandline.cpp
   support/TypeUtil.cpp
   instrumentation/InstrumentationHelper.cpp
   instrumentation/TypeARTFunctions.cpp
   instrumentation/MemOpArgCollector.cpp
   instrumentation/MemOpInstrumentation.cpp
   instrumentation/Instrumentation.cpp
-  ../support/FileConfiguration.cpp
-  ../support/TypeARTOptions.cpp
   TypeARTConfiguration.cpp
+  Commandline.cpp
 )
 
 if(${LLVM_VERSION_MAJOR} VERSION_LESS_EQUAL "14")
@@ -27,6 +26,7 @@ typeart_make_llvm_module(
   LINK_LIBS typeart::MemInstFinder
             typeart::TypesStatic
             typeart::TypeGenDimetaStatic
+            typeart::PassConfiguration
             dimeta::Types
             ${TYPE_IR_GEN}
   INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}

--- a/lib/passes/Commandline.cpp
+++ b/lib/passes/Commandline.cpp
@@ -297,14 +297,18 @@ int enum_to_int(std::string_view cl_value) {
                    .Case("ir", typeart::TypegenImplementation::IR)
                    .Case("dimeta", typeart::TypegenImplementation::DIMETA)
                    .Default(typeart::TypegenImplementation::DIMETA);
-    return static_cast<int>(val);
+    const auto int_val = static_cast<int>(val);
+    LOG_DEBUG("Enum val is " << int_val)
+    return int_val;
   } else {
     auto val = llvm::StringSwitch<ClType>(cl_value.data())
                    .Case("cg", typeart::analysis::FilterImplementation::cg)
                    .Case("none", typeart::analysis::FilterImplementation::none)
                    .Case("std", typeart::analysis::FilterImplementation::standard)
                    .Default(typeart::analysis::FilterImplementation::standard);
-    return static_cast<int>(val);
+    const auto int_val = static_cast<int>(val);
+    LOG_DEBUG("Enum val is " << int_val)
+    return int_val;
   }
 }
 
@@ -413,6 +417,7 @@ EnvironmentFlagsOptions::EnvironmentFlagsOptions() {
   if (!occurence_mapping_.lookup(ConfigStdArgs::global)) {
     const auto stack_value          = mapping_.lookup(ConfigStdArgs::stack);
     mapping_[ConfigStdArgs::global] = OptionValue{static_cast<bool>(stack_value)};
+    occurence_mapping_[ConfigStdArgs::global] = true;
   }
 }
 

--- a/lib/passes/Commandline.cpp
+++ b/lib/passes/Commandline.cpp
@@ -154,10 +154,10 @@ static cl::opt<ConfigStdArgTypes::analysis_filter_pointer_alloc_ty> cl_typeart_f
 namespace typeart::config::cl {
 
 // std::string get_type_file_path() {
-//   if (!cl_typeart_type_file.empty()) {
-//     LOG_DEBUG("Using cl::opt for types file " << cl_typeart_type_file.getValue());
-//     return cl_typeart_type_file.getValue();
-//   }
+// if (!cl_typeart_type_file.empty()) {
+//   LOG_DEBUG("Using cl::opt for types file " << cl_typeart_type_file.getValue());
+//   return cl_typeart_type_file.getValue();
+// }
 //   const char* type_file = std::getenv("TYPEART_TYPE_FILE");
 //   if (type_file != nullptr) {
 //     LOG_DEBUG("Using env var for types file " << type_file)
@@ -198,8 +198,16 @@ CommandLineOptions::CommandLineOptions() {
   using namespace config;
   using namespace typeart::config::cl::detail;
 
+  const auto type_file = [&]() {
+    if (!cl_typeart_type_file.empty()) {
+      LOG_DEBUG("Using cl::opt for types file " << cl_typeart_type_file.getValue());
+      return cl_typeart_type_file.getValue();
+    }
+    return util::get_type_file_path();
+  }();
+
   mapping_ = {
-      make_entry(ConfigStdArgs::types, util::get_type_file_path()),
+      make_entry(ConfigStdArgs::types, type_file),
       make_entry(ConfigStdArgs::stats, cl_typeart_stats),
       make_entry(ConfigStdArgs::heap, cl_typeart_instrument_heap),
       make_entry(ConfigStdArgs::global, cl_typeart_instrument_global),

--- a/lib/passes/Commandline.cpp
+++ b/lib/passes/Commandline.cpp
@@ -394,6 +394,11 @@ EnvironmentFlagsOptions::EnvironmentFlagsOptions() {
       make_occurr_entry(ConfigStdArgs::analysis_filter_alloca_non_array,
                         EnvironmentStdArgs::analysis_filter_alloca_non_array),
   };
+
+  if (!occurence_mapping_.lookup(ConfigStdArgs::global)) {
+    const auto stack_value          = mapping_.lookup(ConfigStdArgs::stack);
+    mapping_[ConfigStdArgs::global] = OptionValue{static_cast<bool>(stack_value)};
+  }
 }
 
 std::optional<typeart::config::OptionValue> EnvironmentFlagsOptions::getValue(std::string_view opt_path) const {

--- a/lib/passes/Commandline.cpp
+++ b/lib/passes/Commandline.cpp
@@ -310,9 +310,13 @@ int enum_to_int(std::string_view cl_value) {
 
 template <typename ClType>
 config::OptionValue make_opt(std::string_view cl_value) {
+  LOG_DEBUG("Parsing value " << cl_value)
   if constexpr (std::is_same_v<bool, ClType>) {
     const bool is_true_val  = with_any_of(cl_value, "true", "TRUE", "1");
     const bool is_false_val = with_any_of(cl_value, "false", "FALSE", "0");
+    if (!(is_true_val || is_false_val)) {
+      LOG_WARNING("Illegal bool value")
+    }
     assert((is_true_val || is_false_val) && "Illegal bool value for environment flag");
     return config::OptionValue{is_true_val};
   } else {
@@ -334,7 +338,7 @@ std::pair<StringRef, typename EnvironmentFlagsOptions::OptionsMap::mapped_type> 
 template <typename ClOpt>
 std::pair<StringRef, typename EnvironmentFlagsOptions::ClOccurrenceMap::mapped_type> make_occurr_entry(
     std::string&& key, ClOpt&& cl_opt) {
-  const bool occured=(util::get_env_flag(cl_opt).has_value());
+  const bool occured = (util::get_env_flag(cl_opt).has_value());
   LOG_DEBUG("Key :" << key << ":" << occured)
   return {key, occured};
 }

--- a/lib/passes/Commandline.cpp
+++ b/lib/passes/Commandline.cpp
@@ -13,7 +13,9 @@
 #include "Commandline.h"
 
 #include "analysis/MemInstFinder.h"
-#include "support/Configuration.h"
+#include "configuration/Configuration.h"
+#include "configuration/EnvironmentConfiguration.h"
+#include "support/ConfigurationBase.h"
 #include "support/Logger.h"
 #include "typegen/TypeGenerator.h"
 
@@ -30,19 +32,9 @@ using namespace llvm;
 namespace typeart::config {
 
 namespace util {
-std::optional<std::string> get_env_flag(std::string_view flag) {
-  const char* env_value = std::getenv(flag.data());
-  const bool exists     = env_value != nullptr;
-  if (exists) {
-    LOG_DEBUG("Using env var " << flag << "=" << env_value)
-    return std::string{env_value};
-  }
-  LOG_DEBUG("Not using env var " << flag << "=<unset>")
-  return {};
-}
 
 std::string get_type_file_path() {
-  auto flag_value = get_env_flag("TYPEART_TYPE_FILE");
+  auto flag_value = env::get_env_flag("TYPEART_TYPE_FILE");
   return flag_value.value_or("types.yaml");
 }
 
@@ -258,169 +250,3 @@ std::optional<typeart::config::OptionValue> CommandLineOptions::getValue(std::st
 }
 
 }  // namespace typeart::config::cl
-
-namespace typeart::config::env {
-
-struct EnvironmentStdArgsValues final {
-#define TYPEART_CONFIG_OPTION(name, path, type, def_value, description, upper_path) \
-  static constexpr char name[] = #def_value;
-#include "support/ConfigurationBaseOptions.h"
-#undef TYPEART_CONFIG_OPTION
-};
-
-}  // namespace typeart::config::env
-
-using typeart::config::ConfigStdArgDescriptions;
-using typeart::config::ConfigStdArgTypes;
-using typeart::config::ConfigStdArgValues;
-using typeart::config::env::EnvironmentStdArgs;
-
-namespace typeart::config::env {
-
-namespace detail {
-template <typename... Strings>
-bool with_any_of(std::string_view lhs, Strings&&... rhs) {
-  return !lhs.empty() && ((lhs == rhs) || ...);
-}
-
-template <typename ClType>
-ClType string_to_enum(std::string_view cl_value) {
-  if constexpr (std::is_same_v<typeart::TypegenImplementation, ClType>) {
-    auto val = llvm::StringSwitch<ClType>(cl_value.data())
-                   .Case("ir", typeart::TypegenImplementation::IR)
-                   .Case("dimeta", typeart::TypegenImplementation::DIMETA)
-                   .Default(typeart::TypegenImplementation::DIMETA);
-    return val;
-  } else {
-    auto val = llvm::StringSwitch<ClType>(cl_value.data())
-                   .Case("cg", typeart::analysis::FilterImplementation::cg)
-                   .Case("none", typeart::analysis::FilterImplementation::none)
-                   .Case("std", typeart::analysis::FilterImplementation::standard)
-                   .Default(typeart::analysis::FilterImplementation::standard);
-    return val;
-  }
-}
-
-template <typename ClType>
-config::OptionValue make_opt(std::string_view cl_value) {
-  LOG_DEBUG("Parsing value " << cl_value)
-  if constexpr (std::is_same_v<bool, ClType>) {
-    const bool is_true_val  = with_any_of(cl_value, "true", "TRUE", "1");
-    const bool is_false_val = with_any_of(cl_value, "false", "FALSE", "0");
-    if (!(is_true_val || is_false_val)) {
-      LOG_WARNING("Illegal bool value")
-    }
-    assert((is_true_val || is_false_val) && "Illegal bool value for environment flag");
-    return config::OptionValue{is_true_val};
-  } else {
-    if constexpr (std::is_enum_v<ClType>) {
-      auto enum_value = string_to_enum<ClType>(cl_value);
-      return config::OptionValue{static_cast<int>(enum_value)};
-    } else {
-      return config::OptionValue{std::string{cl_value}};
-    }
-  }
-}
-
-template <typename ClType>
-std::pair<StringRef, typename OptionsMap::mapped_type> make_entry(std::string&& key, std::string_view cl_opt,
-                                                                  const std::string& default_value) {
-  const auto env_value = util::get_env_flag(cl_opt);
-  return {key, make_opt<ClType>(env_value.value_or(default_value))};
-}
-
-template <typename ClOpt>
-std::pair<StringRef, typename OptOccurrenceMap::mapped_type> make_occurr_entry(std::string&& key, ClOpt&& cl_opt) {
-  const bool occured = (util::get_env_flag(cl_opt).has_value());
-  // LOG_DEBUG("Key :" << key << ":" << occured)
-  return {key, occured};
-}
-}  // namespace detail
-
-EnvironmentFlagsOptions::EnvironmentFlagsOptions() {
-  using namespace config;
-  using namespace typeart::config::env::detail;
-
-  LOG_DEBUG("Construct environment flag options")
-
-  mapping_ = {
-      make_entry<std::string>(ConfigStdArgs::types, "TYPEART_TYPE_FILE", ConfigStdArgValues::types),
-      make_entry<ConfigStdArgTypes::stats_ty>(ConfigStdArgs::stats, EnvironmentStdArgs::stats,
-                                              EnvironmentStdArgsValues::stats),
-      make_entry<ConfigStdArgTypes::heap_ty>(ConfigStdArgs::heap, EnvironmentStdArgs::heap,
-                                             EnvironmentStdArgsValues::heap),
-      make_entry<ConfigStdArgTypes::global_ty>(ConfigStdArgs::global, EnvironmentStdArgs::global,
-                                               EnvironmentStdArgsValues::global),
-      make_entry<ConfigStdArgTypes::stack_ty>(ConfigStdArgs::stack, EnvironmentStdArgs::stack,
-                                              EnvironmentStdArgsValues::stack),
-      make_entry<ConfigStdArgTypes::stack_lifetime_ty>(
-          ConfigStdArgs::stack_lifetime, EnvironmentStdArgs::stack_lifetime, EnvironmentStdArgsValues::stack_lifetime),
-      make_entry<typeart::TypegenImplementation>(ConfigStdArgs::typegen, EnvironmentStdArgs::typegen,
-                                                 ConfigStdArgValues::typegen),
-      make_entry<ConfigStdArgTypes::filter_ty>(ConfigStdArgs::filter, EnvironmentStdArgs::filter,
-                                               EnvironmentStdArgsValues::filter),
-      make_entry<typeart::analysis::FilterImplementation>(ConfigStdArgs::filter_impl, EnvironmentStdArgs::filter_impl,
-                                                          ConfigStdArgValues::filter_impl),
-
-      make_entry<ConfigStdArgTypes::filter_glob_ty>(ConfigStdArgs::filter_glob, EnvironmentStdArgs::filter_glob,
-                                                    ConfigStdArgValues::filter_glob),
-      make_entry<ConfigStdArgTypes::filter_glob_deep_ty>(
-          ConfigStdArgs::filter_glob_deep, EnvironmentStdArgs::filter_glob_deep, ConfigStdArgValues::filter_glob_deep),
-      make_entry<ConfigStdArgTypes::filter_cg_file_ty>(
-          ConfigStdArgs::filter_cg_file, EnvironmentStdArgs::filter_cg_file, ConfigStdArgValues::filter_cg_file),
-      make_entry<ConfigStdArgTypes::analysis_filter_global_ty>(ConfigStdArgs::analysis_filter_global,
-                                                               EnvironmentStdArgs::analysis_filter_global,
-                                                               EnvironmentStdArgsValues::analysis_filter_global),
-      make_entry<ConfigStdArgTypes::analysis_filter_heap_alloc_ty>(
-          ConfigStdArgs::analysis_filter_heap_alloc, EnvironmentStdArgs::analysis_filter_heap_alloc,
-          EnvironmentStdArgsValues::analysis_filter_heap_alloc),
-      make_entry<ConfigStdArgTypes::analysis_filter_pointer_alloc_ty>(
-          ConfigStdArgs::analysis_filter_pointer_alloc, EnvironmentStdArgs::analysis_filter_pointer_alloc,
-          EnvironmentStdArgsValues::analysis_filter_pointer_alloc),
-      make_entry<ConfigStdArgTypes::analysis_filter_alloca_non_array_ty>(
-          ConfigStdArgs::analysis_filter_alloca_non_array, EnvironmentStdArgs::analysis_filter_alloca_non_array,
-          EnvironmentStdArgsValues::analysis_filter_alloca_non_array),
-  };
-
-  occurence_mapping_ = {
-      make_occurr_entry(ConfigStdArgs::types, "TYPEART_TYPE_FILE"),
-      make_occurr_entry(ConfigStdArgs::stats, EnvironmentStdArgs::stats),
-      make_occurr_entry(ConfigStdArgs::heap, EnvironmentStdArgs::heap),
-      make_occurr_entry(ConfigStdArgs::global, EnvironmentStdArgs::global),
-      make_occurr_entry(ConfigStdArgs::stack, EnvironmentStdArgs::stack),
-      make_occurr_entry(ConfigStdArgs::stack_lifetime, EnvironmentStdArgs::stack_lifetime),
-      make_occurr_entry(ConfigStdArgs::typegen, EnvironmentStdArgs::typegen),
-      make_occurr_entry(ConfigStdArgs::filter, EnvironmentStdArgs::filter),
-      make_occurr_entry(ConfigStdArgs::filter_impl, EnvironmentStdArgs::filter_impl),
-      make_occurr_entry(ConfigStdArgs::filter_glob, EnvironmentStdArgs::filter_glob),
-      make_occurr_entry(ConfigStdArgs::filter_glob_deep, EnvironmentStdArgs::filter_glob_deep),
-      make_occurr_entry(ConfigStdArgs::filter_cg_file, EnvironmentStdArgs::filter_cg_file),
-      make_occurr_entry(ConfigStdArgs::analysis_filter_global, EnvironmentStdArgs::analysis_filter_global),
-      make_occurr_entry(ConfigStdArgs::analysis_filter_heap_alloc, EnvironmentStdArgs::analysis_filter_heap_alloc),
-      make_occurr_entry(ConfigStdArgs::analysis_filter_pointer_alloc,
-                        EnvironmentStdArgs::analysis_filter_pointer_alloc),
-      make_occurr_entry(ConfigStdArgs::analysis_filter_alloca_non_array,
-                        EnvironmentStdArgs::analysis_filter_alloca_non_array),
-  };
-
-  if (!occurence_mapping_.lookup(ConfigStdArgs::global) && occurence_mapping_.lookup(ConfigStdArgs::stack)) {
-    const auto stack_value                    = mapping_.lookup(ConfigStdArgs::stack);
-    mapping_[ConfigStdArgs::global]           = OptionValue{static_cast<bool>(stack_value)};
-    occurence_mapping_[ConfigStdArgs::global] = true;
-  }
-}
-
-std::optional<typeart::config::OptionValue> EnvironmentFlagsOptions::getValue(std::string_view opt_path) const {
-  auto key = llvm::StringRef(opt_path.data());
-  if (mapping_.count(key) != 0U) {
-    return mapping_.lookup(key);
-  }
-  return {};
-}
-
-[[maybe_unused]] bool EnvironmentFlagsOptions::valueSpecified(std::string_view opt_path) const {
-  auto key = llvm::StringRef(opt_path.data());
-  return occurence_mapping_.lookup(key);
-}
-
-}  // namespace typeart::config::env

--- a/lib/passes/Commandline.cpp
+++ b/lib/passes/Commandline.cpp
@@ -260,12 +260,6 @@ std::optional<typeart::config::OptionValue> CommandLineOptions::getValue(std::st
 }  // namespace typeart::config::cl
 
 namespace typeart::config::env {
-struct EnvironmentStdArgs final {
-#define TYPEART_CONFIG_OPTION(name, path, type, def_value, description, upper_path) \
-  static constexpr char name[] = "TYPEART_" upper_path;
-#include "support/ConfigurationBaseOptions.h"
-#undef TYPEART_CONFIG_OPTION
-};
 
 struct EnvironmentStdArgsValues final {
 #define TYPEART_CONFIG_OPTION(name, path, type, def_value, description, upper_path) \

--- a/lib/passes/Commandline.cpp
+++ b/lib/passes/Commandline.cpp
@@ -34,10 +34,10 @@ std::optional<std::string> get_env_flag(std::string_view flag) {
   const char* env_value = std::getenv(flag.data());
   const bool exists     = env_value != nullptr;
   if (exists) {
-    LOG_DEBUG("Using env var \"" << flag << "\"=" << env_value)
+    LOG_DEBUG("Using env var " << flag << "=" << env_value)
     return std::string{env_value};
   }
-  LOG_DEBUG("Not using env var \"" << flag << "\"=<unset>")
+  LOG_DEBUG("Not using env var " << flag << "=<unset>")
   return {};
 }
 
@@ -287,8 +287,7 @@ namespace typeart::config::env {
 namespace detail {
 template <typename... Strings>
 bool with_any_of(std::string_view lhs, Strings&&... rhs) {
-  const auto starts_with = [](auto str, std::string_view prefix) { return str == prefix; };
-  return !lhs.empty() && ((starts_with(lhs, std::forward<Strings>(rhs))) || ...);
+  return !lhs.empty() && ((lhs == rhs) || ...);
 }
 
 template <typename ClType>
@@ -335,13 +334,17 @@ std::pair<StringRef, typename EnvironmentFlagsOptions::OptionsMap::mapped_type> 
 template <typename ClOpt>
 std::pair<StringRef, typename EnvironmentFlagsOptions::ClOccurrenceMap::mapped_type> make_occurr_entry(
     std::string&& key, ClOpt&& cl_opt) {
-  return {key, (util::get_env_flag(cl_opt).has_value())};
+  const bool occured=(util::get_env_flag(cl_opt).has_value());
+  LOG_DEBUG("Key :" << key << ":" << occured)
+  return {key, occured};
 }
 }  // namespace detail
 
 EnvironmentFlagsOptions::EnvironmentFlagsOptions() {
   using namespace config;
   using namespace typeart::config::env::detail;
+
+  LOG_DEBUG("Construct environment flag options")
 
   mapping_ = {
       make_entry<std::string>(ConfigStdArgs::types, "TYPEART_TYPE_FILE", ConfigStdArgValues::types),

--- a/lib/passes/Commandline.cpp
+++ b/lib/passes/Commandline.cpp
@@ -243,6 +243,12 @@ CommandLineOptions::CommandLineOptions() {
       make_occurr_entry(ConfigStdArgs::analysis_filter_pointer_alloc, cl_typeart_filter_pointer_alloca),
       make_occurr_entry(ConfigStdArgs::analysis_filter_alloca_non_array, cl_typeart_filter_stack_non_array),
   };
+
+  if (!occurence_mapping_.lookup(ConfigStdArgs::global) && occurence_mapping_.lookup(ConfigStdArgs::stack)) {
+    const auto stack_value          = mapping_.lookup(ConfigStdArgs::stack);
+    mapping_[ConfigStdArgs::global] = OptionValue{static_cast<bool>(stack_value)};
+    occurence_mapping_[ConfigStdArgs::global] = true;
+  }
 }
 
 std::optional<typeart::config::OptionValue> CommandLineOptions::getValue(std::string_view opt_path) const {
@@ -414,7 +420,7 @@ EnvironmentFlagsOptions::EnvironmentFlagsOptions() {
                         EnvironmentStdArgs::analysis_filter_alloca_non_array),
   };
 
-  if (!occurence_mapping_.lookup(ConfigStdArgs::global)) {
+  if (!occurence_mapping_.lookup(ConfigStdArgs::global) && occurence_mapping_.lookup(ConfigStdArgs::stack)) {
     const auto stack_value          = mapping_.lookup(ConfigStdArgs::stack);
     mapping_[ConfigStdArgs::global] = OptionValue{static_cast<bool>(stack_value)};
     occurence_mapping_[ConfigStdArgs::global] = true;

--- a/lib/passes/Commandline.h
+++ b/lib/passes/Commandline.h
@@ -13,7 +13,7 @@
 #ifndef TYPEART_COMMANDLINE_H
 #define TYPEART_COMMANDLINE_H
 
-#include "support/Configuration.h"
+#include "configuration/Configuration.h"
 
 namespace typeart::config::cl {
 
@@ -29,27 +29,5 @@ class CommandLineOptions final : public config::Configuration {
 };
 
 }  // namespace typeart::config::cl
-
-namespace typeart::config::env {
-
-struct EnvironmentStdArgs final {
-#define TYPEART_CONFIG_OPTION(name, path, type, def_value, description, upper_path) \
-  static constexpr char name[] = "TYPEART_" upper_path;
-#include "support/ConfigurationBaseOptions.h"
-#undef TYPEART_CONFIG_OPTION
-};
-
-class EnvironmentFlagsOptions final : public config::Configuration {
- private:
-  OptionsMap mapping_;
-  OptOccurrenceMap occurence_mapping_;
-
- public:
-  EnvironmentFlagsOptions();
-  [[nodiscard]] std::optional<config::OptionValue> getValue(std::string_view opt_path) const override;
-  [[maybe_unused]] [[nodiscard]] bool valueSpecified(std::string_view opt_path) const;
-};
-
-}  // namespace typeart::config::env
 
 #endif  // TYPEART_COMMANDLINE_H

--- a/lib/passes/Commandline.h
+++ b/lib/passes/Commandline.h
@@ -15,18 +15,12 @@
 
 #include "support/Configuration.h"
 
-#include "llvm/ADT/StringMap.h"
-
 namespace typeart::config::cl {
 
 class CommandLineOptions final : public config::Configuration {
- public:
-  using OptionsMap      = llvm::StringMap<config::OptionValue>;
-  using ClOccurrenceMap = llvm::StringMap<bool>;
-
  private:
   OptionsMap mapping_;
-  ClOccurrenceMap occurence_mapping_;
+  OptOccurrenceMap occurence_mapping_;
 
  public:
   CommandLineOptions();
@@ -39,13 +33,9 @@ class CommandLineOptions final : public config::Configuration {
 namespace typeart::config::env {
 
 class EnvironmentFlagsOptions final : public config::Configuration {
- public:
-  using OptionsMap      = llvm::StringMap<config::OptionValue>;
-  using ClOccurrenceMap = llvm::StringMap<bool>;
-
  private:
   OptionsMap mapping_;
-  ClOccurrenceMap occurence_mapping_;
+  OptOccurrenceMap occurence_mapping_;
 
  public:
   EnvironmentFlagsOptions();

--- a/lib/passes/Commandline.h
+++ b/lib/passes/Commandline.h
@@ -36,4 +36,23 @@ class CommandLineOptions final : public config::Configuration {
 
 }  // namespace typeart::config::cl
 
+namespace typeart::config::env {
+
+class EnvironmentFlagsOptions final : public config::Configuration {
+ public:
+  using OptionsMap      = llvm::StringMap<config::OptionValue>;
+  using ClOccurrenceMap = llvm::StringMap<bool>;
+
+ private:
+  OptionsMap mapping_;
+  ClOccurrenceMap occurence_mapping_;
+
+ public:
+  EnvironmentFlagsOptions();
+  [[nodiscard]] std::optional<config::OptionValue> getValue(std::string_view opt_path) const override;
+  [[maybe_unused]] [[nodiscard]] bool valueSpecified(std::string_view opt_path) const;
+};
+
+}  // namespace typeart::config::env
+
 #endif  // TYPEART_COMMANDLINE_H

--- a/lib/passes/Commandline.h
+++ b/lib/passes/Commandline.h
@@ -32,6 +32,13 @@ class CommandLineOptions final : public config::Configuration {
 
 namespace typeart::config::env {
 
+struct EnvironmentStdArgs final {
+#define TYPEART_CONFIG_OPTION(name, path, type, def_value, description, upper_path) \
+  static constexpr char name[] = "TYPEART_" upper_path;
+#include "support/ConfigurationBaseOptions.h"
+#undef TYPEART_CONFIG_OPTION
+};
+
 class EnvironmentFlagsOptions final : public config::Configuration {
  private:
   OptionsMap mapping_;

--- a/lib/passes/TypeARTConfiguration.cpp
+++ b/lib/passes/TypeARTConfiguration.cpp
@@ -101,7 +101,7 @@ std::pair<llvm::StringRef, typename OptionsMap::mapped_type> make_occurr_entry(s
 }
 
 TypeARTConfigOptions TypeARTConfiguration::getOptions() const {
-  return config_to_options(*this);
+  return helper::config_to_options(*this);
 }
 
 inline llvm::ErrorOr<std::unique_ptr<TypeARTConfiguration>> make_config(

--- a/lib/passes/TypeARTConfiguration.cpp
+++ b/lib/passes/TypeARTConfiguration.cpp
@@ -14,6 +14,8 @@
 
 #include "Commandline.h"
 #include "support/FileConfiguration.h"
+#include "support/Logger.h"
+#include <string>
 
 namespace typeart::config {
 
@@ -27,6 +29,7 @@ TypeARTConfiguration::TypeARTConfiguration(std::unique_ptr<file::FileOptions> co
 
 std::optional<OptionValue> TypeARTConfiguration::getValue(std::string_view opt_path) const {
   auto get_value = [&](const auto& options, const char* source) -> std::optional<OptionValue> {
+    LOG_DEBUG("Query " << source << " " << opt_path.data())
     if (prioritize_commandline && options.valueSpecified(opt_path)) {
       LOG_DEBUG("Take " << source << " arg for " << opt_path.data());
       return options.getValue(opt_path);
@@ -44,6 +47,7 @@ std::optional<OptionValue> TypeARTConfiguration::getValue(std::string_view opt_p
 
 OptionValue TypeARTConfiguration::getValueOr(std::string_view opt_path, OptionValue alt) const {
   auto get_value = [&](const auto& options, const char* source) -> std::optional<OptionValue> {
+    LOG_DEBUG("Query " << source << " " << opt_path.data())
     if (prioritize_commandline && options.valueSpecified(opt_path)) {
       LOG_DEBUG("Take " << source << " arg for " << opt_path.data());
       return options.getValueOr(opt_path, alt);
@@ -61,6 +65,7 @@ OptionValue TypeARTConfiguration::getValueOr(std::string_view opt_path, OptionVa
 
 OptionValue TypeARTConfiguration::operator[](std::string_view opt_path) const {
   auto get_value = [&](const auto& options, const char* source) -> std::optional<OptionValue> {
+    LOG_DEBUG("Query " << source << " " << opt_path.data())
     if (prioritize_commandline && options.valueSpecified(opt_path)) {
       LOG_DEBUG("Take " << source << " arg for " << opt_path.data());
       return options.operator[](opt_path);
@@ -73,7 +78,9 @@ OptionValue TypeARTConfiguration::operator[](std::string_view opt_path) const {
   if (auto value = get_value(*commandline_options_, "CL")) {
     return value.value();
   }
-  return configuration_options_->operator[](opt_path);
+  auto result = configuration_options_->operator[](opt_path);
+  LOG_DEBUG("Query file " << static_cast<std::string>(result))
+  return result;
 }
 
 void TypeARTConfiguration::prioritizeCommandline(bool do_prioritize) {

--- a/lib/passes/TypeARTConfiguration.cpp
+++ b/lib/passes/TypeARTConfiguration.cpp
@@ -18,8 +18,11 @@
 namespace typeart::config {
 
 TypeARTConfiguration::TypeARTConfiguration(std::unique_ptr<file::FileOptions> config_options,
-                                           std::unique_ptr<cl::CommandLineOptions> commandline_options)
-    : configuration_options_(std::move(config_options)), commandline_options_(std::move(commandline_options)) {
+                                           std::unique_ptr<cl::CommandLineOptions> commandline_options,
+                                           std::unique_ptr<env::EnvironmentFlagsOptions> env_options)
+    : configuration_options_(std::move(config_options)),
+      commandline_options_(std::move(commandline_options)),
+      env_options_(std::move(env_options)) {
 }
 
 std::optional<OptionValue> TypeARTConfiguration::getValue(std::string_view opt_path) const {
@@ -62,8 +65,10 @@ llvm::ErrorOr<std::unique_ptr<TypeARTConfiguration>> make_typeart_configuration(
                        ? config::file::make_file_configuration(init.file_path)
                        : config::file::make_default_file_configuration();
   if (file_opts) {
-    auto cl_opts = std::make_unique<config::cl::CommandLineOptions>();
-    auto config  = std::make_unique<config::TypeARTConfiguration>(std::move(file_opts.get()), std::move(cl_opts));
+    auto cl_opts  = std::make_unique<config::cl::CommandLineOptions>();
+    auto env_opts = std::make_unique<config::env::EnvironmentFlagsOptions>();
+    auto config   = std::make_unique<config::TypeARTConfiguration>(std::move(file_opts.get()), std::move(cl_opts),
+                                                                 std::move(env_opts));
     config->prioritizeCommandline(true);
     return config;
   }

--- a/lib/passes/TypeARTConfiguration.cpp
+++ b/lib/passes/TypeARTConfiguration.cpp
@@ -13,10 +13,11 @@
 #include "TypeARTConfiguration.h"
 
 #include "Commandline.h"
-#include "support/Configuration.h"
-#include "support/FileConfiguration.h"
+#include "configuration/Configuration.h"
+#include "configuration/EnvironmentConfiguration.h"
+#include "configuration/FileConfiguration.h"
+#include "configuration/TypeARTOptions.h"
 #include "support/Logger.h"
-#include "support/TypeARTOptions.h"
 
 #include <string>
 #include <string_view>

--- a/lib/passes/TypeARTConfiguration.h
+++ b/lib/passes/TypeARTConfiguration.h
@@ -14,6 +14,7 @@
 #define TYPEART_TYPEARTCONFIGURATION_H
 
 #include "support/Configuration.h"
+#include "support/TypeARTOptions.h"
 
 #include "llvm/Support/ErrorOr.h"
 
@@ -47,6 +48,8 @@ class TypeARTConfiguration final : public Configuration {
   [[nodiscard]] OptionValue getValueOr(std::string_view opt_path, OptionValue alt) const override;
   [[nodiscard]] OptionValue operator[](std::string_view opt_path) const override;
   void emitTypeartFileConfiguration(llvm::raw_ostream& out_stream);
+  [[nodiscard]] TypeARTConfigOptions getOptions() const;
+
   ~TypeARTConfiguration() override = default;
 };
 
@@ -58,6 +61,9 @@ struct TypeARTConfigInit {
 
 [[maybe_unused]] llvm::ErrorOr<std::unique_ptr<TypeARTConfiguration>> make_typeart_configuration(
     const TypeARTConfigInit& init);
+
+[[maybe_unused]] llvm::ErrorOr<std::unique_ptr<TypeARTConfiguration>> make_typeart_configuration_from_opts(
+    const TypeARTConfigOptions& opts);
 
 }  // namespace typeart::config
 

--- a/lib/passes/TypeARTConfiguration.h
+++ b/lib/passes/TypeARTConfiguration.h
@@ -27,15 +27,21 @@ namespace cl {
 class CommandLineOptions;
 }  // namespace cl
 
+namespace env {
+class EnvironmentFlagsOptions;
+}
+
 class TypeARTConfiguration final : public Configuration {
  private:
   std::unique_ptr<file::FileOptions> configuration_options_;
   std::unique_ptr<cl::CommandLineOptions> commandline_options_;
+  std::unique_ptr<env::EnvironmentFlagsOptions> env_options_;
   bool prioritize_commandline{true};
 
  public:
   TypeARTConfiguration(std::unique_ptr<file::FileOptions> config_options,
-                       std::unique_ptr<cl::CommandLineOptions> commandline_options);
+                       std::unique_ptr<cl::CommandLineOptions> commandline_options,
+                       std::unique_ptr<env::EnvironmentFlagsOptions> env_options);
   void prioritizeCommandline(bool do_prioritize);
   [[nodiscard]] std::optional<OptionValue> getValue(std::string_view opt_path) const override;
   [[nodiscard]] OptionValue getValueOr(std::string_view opt_path, OptionValue alt) const override;

--- a/lib/passes/TypeARTConfiguration.h
+++ b/lib/passes/TypeARTConfiguration.h
@@ -13,8 +13,8 @@
 #ifndef TYPEART_TYPEARTCONFIGURATION_H
 #define TYPEART_TYPEARTCONFIGURATION_H
 
-#include "support/Configuration.h"
-#include "support/TypeARTOptions.h"
+#include "configuration/Configuration.h"
+#include "configuration/TypeARTOptions.h"
 
 #include "llvm/Support/ErrorOr.h"
 

--- a/lib/passes/TypeARTPass.cpp
+++ b/lib/passes/TypeARTPass.cpp
@@ -123,7 +123,8 @@ class TypeArtPass : public llvm::PassInfoMixin<TypeArtPass> {
     auto config_file_path = get_configuration_file_path();
 
     if (!config_file_path) {
-      pass_config = std::make_unique<config::cl::CommandLineOptions>();
+      auto typeart_config = config::make_typeart_configuration({{},config::TypeARTConfigInit::FileConfigurationMode::Empty});//std::make_unique<config::cl::CommandLineOptions>();
+      pass_config = std::move(*typeart_config);
     } else {
       auto typeart_config = config::make_typeart_configuration({config_file_path.value()});
       if (typeart_config) {

--- a/lib/passes/TypeARTPass.cpp
+++ b/lib/passes/TypeARTPass.cpp
@@ -131,7 +131,7 @@ class TypeArtPass : public llvm::PassInfoMixin<TypeArtPass> {
       LOG_FATAL("Could not load TypeARTConfiguration.")
       std::exit(EXIT_FAILURE);
     }
-    
+
     meminst_finder = analysis::create_finder(*pass_config);
 
     const std::string types_file =
@@ -257,7 +257,7 @@ class TypeArtPass : public llvm::PassInfoMixin<TypeArtPass> {
   bool runOnModule(llvm::Module& m) {
     meminst_finder->runOnModule(m);
     const bool instrument_global = (*pass_config)[config::ConfigStdArgs::global];
-    bool instrumented_global{false};
+    bool globals_were_instrumented{false};
     if (instrument_global) {
       declareInstrumentationFunctions(m);
 
@@ -265,12 +265,12 @@ class TypeArtPass : public llvm::PassInfoMixin<TypeArtPass> {
       if (!globalsList.empty()) {
         const auto global_count = instrumentation_context->handleGlobal(globalsList);
         NumInstrumentedGlobal += global_count;
-        instrumented_global = global_count > 0;
+        globals_were_instrumented = global_count > 0;
       }
     }
 
     const auto instrumented_function = llvm::count_if(m.functions(), [&](auto& f) { return runOnFunc(f); }) > 0;
-    return instrumented_function || instrumented_global;
+    return instrumented_function || globals_were_instrumented;
   }
 
   bool runOnFunc(llvm::Function& f) {

--- a/lib/passes/TypeARTPass.cpp
+++ b/lib/passes/TypeARTPass.cpp
@@ -13,11 +13,12 @@
 #include "Commandline.h"
 #include "TypeARTConfiguration.h"
 #include "analysis/MemInstFinder.h"
+#include "configuration/Configuration.h"
+#include "configuration/EnvironmentConfiguration.h"
+#include "configuration/FileConfiguration.h"
 #include "instrumentation/MemOpArgCollector.h"
 #include "instrumentation/MemOpInstrumentation.h"
 #include "instrumentation/TypeARTFunctions.h"
-#include "support/Configuration.h"
-#include "support/FileConfiguration.h"
 #include "support/Logger.h"
 #include "support/Table.h"
 #include "typegen/TypeGenerator.h"
@@ -122,10 +123,10 @@ class TypeArtPass : public llvm::PassInfoMixin<TypeArtPass> {
       //   typeart_config->get()->emitTypeartFileConfiguration(conf_out_stream);
       //   LOG_INFO("Emitting TypeART file content\n" << conf_out_stream.str())
       // }
-      LOG_INFO("Emitting TypeART file content\n" << typeart_config.get()->getOptions())
+      LOG_INFO("Emitting TypeART configuration content\n" << typeart_config.get()->getOptions())
       pass_config = std::move(*typeart_config);
     } else {
-      LOG_FATAL("Could not load TypeARTConfiguration.")
+      LOG_FATAL("Could not load TypeART configuration.")
       std::exit(EXIT_FAILURE);
     }
 

--- a/lib/passes/TypeARTPass.cpp
+++ b/lib/passes/TypeARTPass.cpp
@@ -116,12 +116,13 @@ class TypeArtPass : public llvm::PassInfoMixin<TypeArtPass> {
                               : config::TypeARTConfigInit{{}, config::TypeARTConfigInit::FileConfigurationMode::Empty};
     auto typeart_config = config::make_typeart_configuration(init);
     if (typeart_config) {
-      {
-        std::string typeart_conf_str;
-        llvm::raw_string_ostream conf_out_stream{typeart_conf_str};
-        typeart_config->get()->emitTypeartFileConfiguration(conf_out_stream);
-        LOG_INFO("Emitting TypeART file content\n" << conf_out_stream.str())
-      }
+      // {
+      //   std::string typeart_conf_str;
+      //   llvm::raw_string_ostream conf_out_stream{typeart_conf_str};
+      //   typeart_config->get()->emitTypeartFileConfiguration(conf_out_stream);
+      //   LOG_INFO("Emitting TypeART file content\n" << conf_out_stream.str())
+      // }
+      LOG_INFO("Emitting TypeART file content\n" << typeart_config.get()->getOptions())
       pass_config = std::move(*typeart_config);
     } else {
       LOG_FATAL("Could not load TypeARTConfiguration.")

--- a/lib/passes/TypeARTPass.cpp
+++ b/lib/passes/TypeARTPass.cpp
@@ -59,10 +59,6 @@ static cl::opt<std::string> cl_typeart_configuration_file(
         "Location of the configuration file to configure the TypeART pass. Commandline arguments are prioritized."),
     cl::cat(typeart_category));
 
-static cl::opt<bool> cl_typeart_configuration_file_dump("typeart-config-dump", cl::init(false), cl::Hidden,
-                                                        cl::desc("Dump default config file content to std::out."),
-                                                        cl::cat(typeart_category));
-
 #define DEBUG_TYPE "typeart"
 
 ALWAYS_ENABLED_STATISTIC(NumInstrumentedMallocs, "Number of instrumented mallocs");

--- a/lib/passes/analysis/MemInstFinder.cpp
+++ b/lib/passes/analysis/MemInstFinder.cpp
@@ -462,6 +462,7 @@ const GlobalDataList& MemInstFinderPass::getModuleGlobals() const {
 }
 
 std::unique_ptr<MemInstFinder> create_finder(const config::Configuration& config) {
+  LOG_DEBUG("Constructing MemInstFinder")
   using typeart::config::ConfigStdArgs;
   const auto meminst_config = [&config]() {
     return analysis::MemInstFinderConfig{
@@ -478,6 +479,7 @@ std::unique_ptr<MemInstFinder> create_finder(const config::Configuration& config
                                               config[ConfigStdArgs::analysis_filter_global],            //
                                               config[ConfigStdArgs::analysis_filter_pointer_alloc]}};   //
   }();
+  LOG_DEBUG("Return finder")
   return std::make_unique<MemInstFinderPass>(meminst_config);
 }
 

--- a/lib/passes/analysis/MemInstFinder.cpp
+++ b/lib/passes/analysis/MemInstFinder.cpp
@@ -15,15 +15,15 @@
 #include "MemOpVisitor.h"
 #include "TypeARTConfiguration.h"
 #include "analysis/MemOpData.h"
+#include "configuration/Configuration.h"
+#include "configuration/TypeARTOptions.h"
 #include "filter/CGForwardFilter.h"
 #include "filter/CGInterface.h"
 #include "filter/Filter.h"
 #include "filter/Matcher.h"
 #include "filter/StdForwardFilter.h"
-#include "support/Configuration.h"
 #include "support/Logger.h"
 #include "support/Table.h"
-#include "support/TypeARTOptions.h"
 #include "support/TypeUtil.h"
 #include "support/Util.h"
 
@@ -450,7 +450,7 @@ const GlobalDataList& MemInstFinderPass::getModuleGlobals() const {
 std::unique_ptr<MemInstFinder> create_finder(const config::Configuration& config) {
   LOG_DEBUG("Constructing MemInstFinder")
   const auto meminst_conf = config::helper::config_to_options(config);
-  return std::make_unique<MemInstFinderPass>( meminst_conf);
+  return std::make_unique<MemInstFinderPass>(meminst_conf);
 }
 
 }  // namespace typeart::analysis

--- a/lib/passes/analysis/MemInstFinder.cpp
+++ b/lib/passes/analysis/MemInstFinder.cpp
@@ -13,6 +13,7 @@
 #include "MemInstFinder.h"
 
 #include "MemOpVisitor.h"
+#include "TypeARTConfiguration.h"
 #include "analysis/MemOpData.h"
 #include "filter/CGForwardFilter.h"
 #include "filter/CGInterface.h"
@@ -22,6 +23,7 @@
 #include "support/Configuration.h"
 #include "support/Logger.h"
 #include "support/Table.h"
+#include "support/TypeARTOptions.h"
 #include "support/TypeUtil.h"
 #include "support/Util.h"
 
@@ -59,24 +61,7 @@ ALWAYS_ENABLED_STATISTIC(NumCallFilteredGlobals, "Number of filtered globals");
 
 namespace typeart::analysis {
 
-struct MemInstFinderConfig {
-  struct Filter {
-    bool useCallFilter{false};
-    FilterImplementation implementation{FilterImplementation::standard};
-    std::string callFilterGlob{"*MPI_*"};
-    std::string callFilterDeepGlob{"MPI_*"};
-    std::string callFilterCgFile{};
-    bool filterNonArrayAlloca{false};
-    bool filterMallocAllocPair{false};
-    bool filterGlobal{true};
-    bool filterPointerAlloca{false};
-  };
-
-  bool collect_heap{false};
-  bool collect_alloca{false};
-  bool collect_global{false};
-  Filter filter;
-};
+using MemInstFinderConfig = config::TypeARTConfigOptions;
 
 namespace filter {
 class CallFilter {
@@ -100,25 +85,25 @@ namespace filter {
 namespace detail {
 static std::unique_ptr<typeart::filter::Filter> make_filter(const MemInstFinderConfig& config) {
   using namespace typeart::filter;
-  const auto filter_id   = config.filter.implementation;
-  const std::string glob = config.filter.callFilterGlob;
+  const auto filter_id   = config.call_filter_configuration.implementation;
+  const std::string glob = config.call_filter_configuration.glob;
 
-  if (filter_id == FilterImplementation::none || !config.filter.useCallFilter) {
+  if (filter_id == FilterImplementation::none || !config.filter) {
     LOG_DEBUG("Return no-op filter")
     return std::make_unique<NoOpFilter>();
   } else if (filter_id == FilterImplementation::cg) {
-    if (config.filter.callFilterCgFile.empty()) {
+    if (config.call_filter_configuration.cg_file.empty()) {
       LOG_FATAL("CG File not set!");
       std::exit(1);
     }
-    LOG_DEBUG("Return CG filter with CG file @ " << config.filter.callFilterCgFile)
-    auto json_cg = JSONCG::getJSON(config.filter.callFilterCgFile);
+    LOG_DEBUG("Return CG filter with CG file @ " << config.call_filter_configuration.cg_file)
+    auto json_cg = JSONCG::getJSON(config.call_filter_configuration.cg_file);
     auto matcher = std::make_unique<DefaultStringMatcher>(util::glob2regex(glob));
     return std::make_unique<CGForwardFilter>(glob, std::move(json_cg), std::move(matcher));
   } else {
     LOG_DEBUG("Return default filter")
     auto matcher         = std::make_unique<DefaultStringMatcher>(util::glob2regex(glob));
-    const auto deep_glob = config.filter.callFilterDeepGlob;
+    const auto deep_glob = config.call_filter_configuration.glob_deep;
     auto deep_matcher    = std::make_unique<DefaultStringMatcher>(util::glob2regex(deep_glob));
     return std::make_unique<StandardForwardFilter>(std::move(matcher), std::move(deep_matcher));
   }
@@ -181,15 +166,15 @@ class MemInstFinderPass : public MemInstFinder {
   bool runOnFunction(llvm::Function&);
 };
 
-MemInstFinderPass::MemInstFinderPass(const MemInstFinderConfig& config)
-    : mOpsCollector(config.collect_alloca, config.collect_heap), filter(config), config(config) {
+MemInstFinderPass::MemInstFinderPass(const MemInstFinderConfig& conf_)
+    : mOpsCollector(conf_.stack, conf_.heap), filter(conf_), config(conf_) {
 }
 
 bool MemInstFinderPass::runOnModule(Module& module) {
   mOpsCollector.collectGlobals(module);
   auto& globals = mOpsCollector.globals;
   NumDetectedGlobals += globals.size();
-  if (config.filter.filterGlobal) {
+  if (config.analysis_configuration.filter_global) {
     globals.erase(llvm::remove_if(
                       globals,
                       [&](const auto gdata) {  // NOLINT
@@ -310,7 +295,7 @@ bool MemInstFinderPass::runOnFunction(llvm::Function& function) {
 
   NumDetectedAllocs += mOpsCollector.allocas.size();
 
-  if (config.filter.filterNonArrayAlloca) {
+  if (config.analysis_configuration.filter_alloca_non_array) {
     auto& allocs = mOpsCollector.allocas;
     allocs.erase(llvm::remove_if(allocs,
                                  [&](const auto& data) {
@@ -323,7 +308,7 @@ bool MemInstFinderPass::runOnFunction(llvm::Function& function) {
                  allocs.end());
   }
 
-  if (config.filter.filterMallocAllocPair) {
+  if (config.analysis_configuration.filter_heap_alloc) {
     auto& allocs  = mOpsCollector.allocas;
     auto& mallocs = mOpsCollector.mallocs;
 
@@ -359,7 +344,7 @@ bool MemInstFinderPass::runOnFunction(llvm::Function& function) {
                  allocs.end());
   }
 
-  if (config.filter.filterPointerAlloca) {
+  if (config.analysis_configuration.filter_pointer_alloc) {
     auto& allocs = mOpsCollector.allocas;
     allocs.erase(llvm::remove_if(allocs,
                                  [&](const auto& data) {
@@ -373,7 +358,8 @@ bool MemInstFinderPass::runOnFunction(llvm::Function& function) {
                  allocs.end());
   }
 
-  if (config.filter.useCallFilter) {
+  // if (config.filter.useCallFilter) {
+  if (config.filter) {
     auto& allocs = mOpsCollector.allocas;
     allocs.erase(llvm::remove_if(allocs,
                                  [&](const auto& data) {
@@ -428,7 +414,7 @@ void MemInstFinderPass::printStats(llvm::raw_ostream& out) const {
   Table stats("MemInstFinderPass");
   stats.wrap_header = true;
   stats.wrap_length = true;
-  stats.put(Row::make("Filter string", config.filter.callFilterGlob));
+  stats.put(Row::make("Filter string", config.call_filter_configuration.glob));
   stats.put(Row::make_row("> Heap Memory"));
   stats.put(Row::make("Heap alloc", NumDetectedHeap.getValue()));
   stats.put(Row::make("Heap call filtered %", call_filter_heap_p));
@@ -463,24 +449,8 @@ const GlobalDataList& MemInstFinderPass::getModuleGlobals() const {
 
 std::unique_ptr<MemInstFinder> create_finder(const config::Configuration& config) {
   LOG_DEBUG("Constructing MemInstFinder")
-  using typeart::config::ConfigStdArgs;
-  const auto meminst_config = [&config]() {
-    return analysis::MemInstFinderConfig{
-        config[ConfigStdArgs::heap],                                                                    //
-        config[ConfigStdArgs::stack],                                                                   //
-        config[ConfigStdArgs::global],                                                                  //
-        analysis::MemInstFinderConfig::Filter{config[ConfigStdArgs::filter],                            //
-                                              config[ConfigStdArgs::filter_impl],                       //
-                                              config[ConfigStdArgs::filter_glob],                       //
-                                              config[ConfigStdArgs::filter_glob_deep],                  //
-                                              config[ConfigStdArgs::filter_cg_file],                    //
-                                              config[ConfigStdArgs::analysis_filter_alloca_non_array],  //
-                                              config[ConfigStdArgs::analysis_filter_heap_alloc],        //
-                                              config[ConfigStdArgs::analysis_filter_global],            //
-                                              config[ConfigStdArgs::analysis_filter_pointer_alloc]}};   //
-  }();
-  LOG_DEBUG("Return finder")
-  return std::make_unique<MemInstFinderPass>(meminst_config);
+  const auto meminst_conf = config::config_to_options(config);
+  return std::make_unique<MemInstFinderPass>( meminst_conf);
 }
 
 }  // namespace typeart::analysis

--- a/lib/passes/configuration/CMakeLists.txt
+++ b/lib/passes/configuration/CMakeLists.txt
@@ -1,0 +1,38 @@
+set(CONFIG_SOURCES
+  FileConfiguration.cpp
+  EnvironmentConfiguration.cpp
+  TypeARTOptions.cpp
+)
+
+add_library(${TYPEART_PREFIX}_PassConfiguration STATIC ${CONFIG_SOURCES})
+
+set_target_properties(
+  ${TYPEART_PREFIX}_PassConfiguration
+  PROPERTIES
+  OUTPUT_NAME "${PROJECT_NAME}PassConfiguration"
+  EXPORT_NAME "PassConfiguration"
+)
+
+add_library(typeart::PassConfiguration ALIAS ${TYPEART_PREFIX}_PassConfiguration)
+
+target_compile_definitions(
+  ${TYPEART_PREFIX}_PassConfiguration PRIVATE TYPEART_LOG_LEVEL=${TYPEART_LOG_LEVEL}
+                                              LLVM_VERSION_MAJOR=${LLVM_VERSION_MAJOR}
+)
+
+set_target_properties(${TYPEART_PREFIX}_PassConfiguration PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+target_include_directories(
+  ${TYPEART_PREFIX}_PassConfiguration ${warning_guard}
+  PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib>
+         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib/passes>
+)
+
+target_include_directories(${TYPEART_PREFIX}_PassConfiguration SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS})
+
+make_tidy_check(${TYPEART_PREFIX}_PassConfiguration "${CONFIG_SOURCES}")
+
+typeart_target_compile_options(${TYPEART_PREFIX}_PassConfiguration)
+typeart_target_define_file_basename(${TYPEART_PREFIX}_PassConfiguration)
+typeart_target_coverage_options(${TYPEART_PREFIX}_PassConfiguration)

--- a/lib/passes/configuration/Configuration.h
+++ b/lib/passes/configuration/Configuration.h
@@ -25,32 +25,6 @@
 
 namespace typeart::config {
 
-struct ConfigStdArgs final {
-#define TYPEART_CONFIG_OPTION(name, path, type, def_value, description, upper_path) static constexpr char name[] = path;
-#include "ConfigurationBaseOptions.h"
-#undef TYPEART_CONFIG_OPTION
-};
-
-struct ConfigStdArgValues final {
-#define TYPEART_CONFIG_OPTION(name, path, type, def_value, description, upper_path) \
-  static constexpr decltype(def_value) name{def_value};
-#include "ConfigurationBaseOptions.h"
-#undef TYPEART_CONFIG_OPTION
-};
-
-struct ConfigStdArgTypes final {
-#define TYPEART_CONFIG_OPTION(name, path, type, default_value, description, upper_path) using name##_ty = type;
-#include "ConfigurationBaseOptions.h"
-#undef TYPEART_CONFIG_OPTION
-};
-
-struct ConfigStdArgDescriptions final {
-#define TYPEART_CONFIG_OPTION(name, path, type, default_value, description, upper_path) \
-  static constexpr char name[] = description;
-#include "ConfigurationBaseOptions.h"
-#undef TYPEART_CONFIG_OPTION
-};
-
 namespace detail {
 template <typename T, typename Types>
 struct VariantContains;

--- a/lib/passes/configuration/EnvironmentConfiguration.cpp
+++ b/lib/passes/configuration/EnvironmentConfiguration.cpp
@@ -1,0 +1,195 @@
+// TypeART library
+//
+// Copyright (c) 2017-2025 TypeART Authors
+// Distributed under the BSD 3-Clause license.
+// (See accompanying file LICENSE.txt or copy at
+// https://opensource.org/licenses/BSD-3-Clause)
+//
+// Project home: https://github.com/tudasc/TypeART
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#include "EnvironmentConfiguration.h"
+
+#include "Configuration.h"
+#include "analysis/MemInstFinder.h"
+#include "support/ConfigurationBase.h"
+#include "support/Logger.h"
+#include "support/Util.h"
+#include "typegen/TypeGenerator.h"
+
+#include "llvm/ADT/StringSwitch.h"
+
+#include <charconv>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+using namespace llvm;
+
+namespace typeart::config::env {
+std::optional<std::string> get_env_flag(std::string_view flag) {
+  const char* env_value = std::getenv(flag.data());
+  const bool exists     = env_value != nullptr;
+  if (exists) {
+    LOG_DEBUG("Using env var " << flag << "=" << env_value)
+    return std::string{env_value};
+  }
+  LOG_DEBUG("Not using env var " << flag << "=<unset>")
+  return {};
+}
+
+}  // namespace typeart::config::env
+
+namespace typeart::config::env {
+
+namespace detail {
+template <typename... Strings>
+bool with_any_of(std::string_view lhs, Strings&&... rhs) {
+  return !lhs.empty() && ((lhs == rhs) || ...);
+}
+
+template <typename ClType>
+ClType string_to_enum(std::string_view cl_value) {
+  using ::typeart::TypegenImplementation;
+  using ::typeart::analysis::FilterImplementation;
+  if constexpr (std::is_same_v<TypegenImplementation, ClType>) {
+    auto val = llvm::StringSwitch<ClType>(cl_value.data())
+                   .Case("ir", TypegenImplementation::IR)
+                   .Case("dimeta", TypegenImplementation::DIMETA)
+                   .Default(TypegenImplementation::DIMETA);
+    return val;
+  } else {
+    auto val = llvm::StringSwitch<ClType>(cl_value.data())
+                   .Case("cg", FilterImplementation::cg)
+                   .Case("none", FilterImplementation::none)
+                   .Case("std", FilterImplementation::standard)
+                   .Default(FilterImplementation::standard);
+    return val;
+  }
+}
+
+template <typename ClType>
+config::OptionValue make_opt(std::string_view cl_value) {
+  LOG_DEBUG("Parsing value " << cl_value)
+  if constexpr (std::is_same_v<bool, ClType>) {
+    const bool is_true_val  = with_any_of(cl_value, "true", "TRUE", "1");
+    const bool is_false_val = with_any_of(cl_value, "false", "FALSE", "0");
+    if (!(is_true_val || is_false_val)) {
+      LOG_WARNING("Illegal bool value")
+    }
+    assert((is_true_val || is_false_val) && "Illegal bool value for environment flag");
+    return config::OptionValue{is_true_val};
+  } else {
+    if constexpr (std::is_enum_v<ClType>) {
+      auto enum_value = string_to_enum<ClType>(cl_value);
+      return config::OptionValue{static_cast<int>(enum_value)};
+    } else {
+      return config::OptionValue{std::string{cl_value}};
+    }
+  }
+}
+
+template <typename ClType>
+std::pair<StringRef, typename OptionsMap::mapped_type> make_entry(std::string&& key, std::string_view cl_opt,
+                                                                  const std::string& default_value) {
+  const auto env_value = get_env_flag(cl_opt);
+  return {key, make_opt<ClType>(env_value.value_or(default_value))};
+}
+
+template <typename ClOpt>
+std::pair<StringRef, typename OptOccurrenceMap::mapped_type> make_occurr_entry(std::string&& key, ClOpt&& cl_opt) {
+  const bool occured = (get_env_flag(cl_opt).has_value());
+  // LOG_DEBUG("Key :" << key << ":" << occured)
+  return {key, occured};
+}
+}  // namespace detail
+
+EnvironmentFlagsOptions::EnvironmentFlagsOptions() {
+  using namespace config;
+  using namespace typeart::config::env::detail;
+
+  LOG_DEBUG("Construct environment flag options")
+
+  mapping_ = {
+      make_entry<std::string>(ConfigStdArgs::types, "TYPEART_TYPE_FILE", ConfigStdArgValues::types),
+      make_entry<ConfigStdArgTypes::stats_ty>(ConfigStdArgs::stats, EnvironmentStdArgs::stats,
+                                              EnvironmentStdArgsValues::stats),
+      make_entry<ConfigStdArgTypes::heap_ty>(ConfigStdArgs::heap, EnvironmentStdArgs::heap,
+                                             EnvironmentStdArgsValues::heap),
+      make_entry<ConfigStdArgTypes::global_ty>(ConfigStdArgs::global, EnvironmentStdArgs::global,
+                                               EnvironmentStdArgsValues::global),
+      make_entry<ConfigStdArgTypes::stack_ty>(ConfigStdArgs::stack, EnvironmentStdArgs::stack,
+                                              EnvironmentStdArgsValues::stack),
+      make_entry<ConfigStdArgTypes::stack_lifetime_ty>(
+          ConfigStdArgs::stack_lifetime, EnvironmentStdArgs::stack_lifetime, EnvironmentStdArgsValues::stack_lifetime),
+      make_entry<typeart::TypegenImplementation>(ConfigStdArgs::typegen, EnvironmentStdArgs::typegen,
+                                                 ConfigStdArgValues::typegen),
+      make_entry<ConfigStdArgTypes::filter_ty>(ConfigStdArgs::filter, EnvironmentStdArgs::filter,
+                                               EnvironmentStdArgsValues::filter),
+      make_entry<typeart::analysis::FilterImplementation>(ConfigStdArgs::filter_impl, EnvironmentStdArgs::filter_impl,
+                                                          ConfigStdArgValues::filter_impl),
+
+      make_entry<ConfigStdArgTypes::filter_glob_ty>(ConfigStdArgs::filter_glob, EnvironmentStdArgs::filter_glob,
+                                                    ConfigStdArgValues::filter_glob),
+      make_entry<ConfigStdArgTypes::filter_glob_deep_ty>(
+          ConfigStdArgs::filter_glob_deep, EnvironmentStdArgs::filter_glob_deep, ConfigStdArgValues::filter_glob_deep),
+      make_entry<ConfigStdArgTypes::filter_cg_file_ty>(
+          ConfigStdArgs::filter_cg_file, EnvironmentStdArgs::filter_cg_file, ConfigStdArgValues::filter_cg_file),
+      make_entry<ConfigStdArgTypes::analysis_filter_global_ty>(ConfigStdArgs::analysis_filter_global,
+                                                               EnvironmentStdArgs::analysis_filter_global,
+                                                               EnvironmentStdArgsValues::analysis_filter_global),
+      make_entry<ConfigStdArgTypes::analysis_filter_heap_alloc_ty>(
+          ConfigStdArgs::analysis_filter_heap_alloc, EnvironmentStdArgs::analysis_filter_heap_alloc,
+          EnvironmentStdArgsValues::analysis_filter_heap_alloc),
+      make_entry<ConfigStdArgTypes::analysis_filter_pointer_alloc_ty>(
+          ConfigStdArgs::analysis_filter_pointer_alloc, EnvironmentStdArgs::analysis_filter_pointer_alloc,
+          EnvironmentStdArgsValues::analysis_filter_pointer_alloc),
+      make_entry<ConfigStdArgTypes::analysis_filter_alloca_non_array_ty>(
+          ConfigStdArgs::analysis_filter_alloca_non_array, EnvironmentStdArgs::analysis_filter_alloca_non_array,
+          EnvironmentStdArgsValues::analysis_filter_alloca_non_array),
+  };
+
+  occurence_mapping_ = {
+      make_occurr_entry(ConfigStdArgs::types, "TYPEART_TYPE_FILE"),
+      make_occurr_entry(ConfigStdArgs::stats, EnvironmentStdArgs::stats),
+      make_occurr_entry(ConfigStdArgs::heap, EnvironmentStdArgs::heap),
+      make_occurr_entry(ConfigStdArgs::global, EnvironmentStdArgs::global),
+      make_occurr_entry(ConfigStdArgs::stack, EnvironmentStdArgs::stack),
+      make_occurr_entry(ConfigStdArgs::stack_lifetime, EnvironmentStdArgs::stack_lifetime),
+      make_occurr_entry(ConfigStdArgs::typegen, EnvironmentStdArgs::typegen),
+      make_occurr_entry(ConfigStdArgs::filter, EnvironmentStdArgs::filter),
+      make_occurr_entry(ConfigStdArgs::filter_impl, EnvironmentStdArgs::filter_impl),
+      make_occurr_entry(ConfigStdArgs::filter_glob, EnvironmentStdArgs::filter_glob),
+      make_occurr_entry(ConfigStdArgs::filter_glob_deep, EnvironmentStdArgs::filter_glob_deep),
+      make_occurr_entry(ConfigStdArgs::filter_cg_file, EnvironmentStdArgs::filter_cg_file),
+      make_occurr_entry(ConfigStdArgs::analysis_filter_global, EnvironmentStdArgs::analysis_filter_global),
+      make_occurr_entry(ConfigStdArgs::analysis_filter_heap_alloc, EnvironmentStdArgs::analysis_filter_heap_alloc),
+      make_occurr_entry(ConfigStdArgs::analysis_filter_pointer_alloc,
+                        EnvironmentStdArgs::analysis_filter_pointer_alloc),
+      make_occurr_entry(ConfigStdArgs::analysis_filter_alloca_non_array,
+                        EnvironmentStdArgs::analysis_filter_alloca_non_array),
+  };
+
+  if (!occurence_mapping_.lookup(ConfigStdArgs::global) && occurence_mapping_.lookup(ConfigStdArgs::stack)) {
+    const auto stack_value                    = mapping_.lookup(ConfigStdArgs::stack);
+    mapping_[ConfigStdArgs::global]           = OptionValue{static_cast<bool>(stack_value)};
+    occurence_mapping_[ConfigStdArgs::global] = true;
+  }
+}
+
+std::optional<typeart::config::OptionValue> EnvironmentFlagsOptions::getValue(std::string_view opt_path) const {
+  auto key = llvm::StringRef(opt_path.data());
+  if (mapping_.count(key) != 0U) {
+    return mapping_.lookup(key);
+  }
+  return {};
+}
+
+[[maybe_unused]] bool EnvironmentFlagsOptions::valueSpecified(std::string_view opt_path) const {
+  auto key = llvm::StringRef(opt_path.data());
+  return occurence_mapping_.lookup(key);
+}
+
+}  // namespace typeart::config::env

--- a/lib/passes/configuration/EnvironmentConfiguration.cpp
+++ b/lib/passes/configuration/EnvironmentConfiguration.cpp
@@ -100,9 +100,9 @@ std::pair<StringRef, typename OptionsMap::mapped_type> make_entry(std::string&& 
 
 template <typename ClOpt>
 std::pair<StringRef, typename OptOccurrenceMap::mapped_type> make_occurr_entry(std::string&& key, ClOpt&& cl_opt) {
-  const bool occured = (get_env_flag(cl_opt).has_value());
-  // LOG_DEBUG("Key :" << key << ":" << occured)
-  return {key, occured};
+  const bool occurred = (get_env_flag(cl_opt).has_value());
+  // LOG_DEBUG("Key :" << key << ":" << occurred)
+  return {key, occurred};
 }
 }  // namespace detail
 

--- a/lib/passes/configuration/EnvironmentConfiguration.h
+++ b/lib/passes/configuration/EnvironmentConfiguration.h
@@ -1,0 +1,49 @@
+// TypeART library
+//
+// Copyright (c) 2017-2025 TypeART Authors
+// Distributed under the BSD 3-Clause license.
+// (See accompanying file LICENSE.txt or copy at
+// https://opensource.org/licenses/BSD-3-Clause)
+//
+// Project home: https://github.com/tudasc/TypeART
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#ifndef TYPEART_ENVIRONMENT_CONFIGURATION_H
+#define TYPEART_ENVIRONMENT_CONFIGURATION_H
+
+#include "configuration/Configuration.h"
+
+namespace typeart::config::env {
+
+std::optional<std::string> get_env_flag(std::string_view flag);
+
+struct EnvironmentStdArgsValues final {
+#define TYPEART_CONFIG_OPTION(name, path, type, def_value, description, upper_path) \
+  static constexpr char name[] = #def_value;
+#include "support/ConfigurationBaseOptions.h"
+#undef TYPEART_CONFIG_OPTION
+};
+
+struct EnvironmentStdArgs final {
+#define TYPEART_CONFIG_OPTION(name, path, type, def_value, description, upper_path) \
+  static constexpr char name[] = "TYPEART_" upper_path;
+#include "support/ConfigurationBaseOptions.h"
+#undef TYPEART_CONFIG_OPTION
+};
+
+class EnvironmentFlagsOptions final : public config::Configuration {
+ private:
+  OptionsMap mapping_;
+  OptOccurrenceMap occurence_mapping_;
+
+ public:
+  EnvironmentFlagsOptions();
+  [[nodiscard]] std::optional<config::OptionValue> getValue(std::string_view opt_path) const override;
+  [[maybe_unused]] [[nodiscard]] bool valueSpecified(std::string_view opt_path) const;
+};
+
+}  // namespace typeart::config::env
+
+#endif

--- a/lib/passes/configuration/FileConfiguration.cpp
+++ b/lib/passes/configuration/FileConfiguration.cpp
@@ -12,10 +12,10 @@
 
 #include "FileConfiguration.h"
 
+#include "Configuration.h"
 #include "TypeARTConfiguration.h"
 #include "TypeARTOptions.h"
 #include "analysis/MemInstFinder.h"
-#include "support/Configuration.h"
 #include "typegen/TypeGenerator.h"
 
 #include "llvm/ADT/StringMap.h"
@@ -31,8 +31,6 @@
 using namespace llvm;
 
 namespace typeart::config::file {
-
-using typeart::config::ConfigStdArgValues;
 
 std::string write_file_configuration_as_text(const FileOptions& file_options);
 
@@ -72,7 +70,6 @@ std::string YamlFileConfiguration::getConfigurationAsString() const {
   return write_file_configuration_as_text(*this);
 }
 
-
 namespace compat {
 auto open_flag() {
 #if LLVM_VERSION_MAJOR < 13
@@ -108,10 +105,10 @@ llvm::ErrorOr<std::unique_ptr<FileOptions>> make_from_configuration(const TypeAR
   return std::make_unique<YamlFileConfiguration>(options);
 }
 
-llvm::ErrorOr<bool> write_file_configuration(llvm::raw_ostream& oss, const FileOptions& options) {
+llvm::ErrorOr<bool> write_file_configuration(llvm::raw_ostream& out_stream, const FileOptions& options) {
   using namespace llvm;
 
-  llvm::yaml::Output out(oss);
+  llvm::yaml::Output out(out_stream);
 
   auto data = options.getConfiguration();
 

--- a/lib/passes/configuration/FileConfiguration.h
+++ b/lib/passes/configuration/FileConfiguration.h
@@ -13,7 +13,7 @@
 #ifndef TYPEART_FILECONFIGURATION_H
 #define TYPEART_FILECONFIGURATION_H
 
-#include "support/Configuration.h"
+#include "configuration/Configuration.h"
 
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/ErrorOr.h"

--- a/lib/passes/configuration/TypeARTOptions.cpp
+++ b/lib/passes/configuration/TypeARTOptions.cpp
@@ -25,7 +25,7 @@ using namespace llvm::yaml;
 using namespace typeart::config::file;
 
 template <>
-struct ScalarEnumerationTraits<typeart::analysis::FilterImplementation> {
+struct llvm::yaml::ScalarEnumerationTraits<typeart::analysis::FilterImplementation> {
   static void enumeration(IO& io, typeart::analysis::FilterImplementation& value) {
     io.enumCase(value, "cg", typeart::analysis::FilterImplementation::cg);
     io.enumCase(value, "std", typeart::analysis::FilterImplementation::standard);
@@ -34,7 +34,7 @@ struct ScalarEnumerationTraits<typeart::analysis::FilterImplementation> {
 };
 
 template <>
-struct ScalarEnumerationTraits<typeart::TypegenImplementation> {
+struct llvm::yaml::ScalarEnumerationTraits<typeart::TypegenImplementation> {
   static void enumeration(IO& io, typeart::TypegenImplementation& value) {
     io.enumCase(value, "dimeta", typeart::TypegenImplementation::DIMETA);
     io.enumCase(value, "ir", typeart::TypegenImplementation::IR);

--- a/lib/passes/configuration/TypeARTOptions.cpp
+++ b/lib/passes/configuration/TypeARTOptions.cpp
@@ -1,9 +1,19 @@
-
+// TypeART library
+//
+// Copyright (c) 2017-2025 TypeART Authors
+// Distributed under the BSD 3-Clause license.
+// (See accompanying file LICENSE.txt or copy at
+// https://opensource.org/licenses/BSD-3-Clause)
+//
+// Project home: https://github.com/tudasc/TypeART
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
 
 #include "TypeARTOptions.h"
 
+#include "Configuration.h"
 #include "FileConfiguration.h"
-#include "support/Configuration.h"
 
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -98,7 +108,7 @@ void yaml_output_file(llvm::yaml::Output& output, const TypeARTConfigOptions& co
 }  // namespace typeart::config::io::yaml
 
 namespace typeart::config {
-  
+
 llvm::raw_ostream& operator<<(llvm::raw_ostream& out_stream, const TypeARTConfigOptions& options) {
   std::string config_text;
   llvm::raw_string_ostream sstream(config_text);

--- a/lib/passes/configuration/TypeARTOptions.h
+++ b/lib/passes/configuration/TypeARTOptions.h
@@ -1,9 +1,22 @@
-#ifndef C86BA97A_734C_4A62_A56E_9E38A9E55DE6
-#define C86BA97A_734C_4A62_A56E_9E38A9E55DE6
+// TypeART library
+//
+// Copyright (c) 2017-2025 TypeART Authors
+// Distributed under the BSD 3-Clause license.
+// (See accompanying file LICENSE.txt or copy at
+// https://opensource.org/licenses/BSD-3-Clause)
+//
+// Project home: https://github.com/tudasc/TypeART
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
 
-#include "../passes/analysis/MemInstFinder.h"
-#include "../passes/typegen/TypeGenerator.h"
-#include "support/Configuration.h"
+#ifndef TYPEART_OPTIONS_H
+#define TYPEART_OPTIONS_H
+
+#include "analysis/MemInstFinder.h"
+#include "configuration/Configuration.h"
+#include "support/ConfigurationBase.h"
+#include "typegen/TypeGenerator.h"
 
 namespace llvm::yaml {
 class Input;
@@ -63,4 +76,4 @@ llvm::raw_ostream& operator<<(llvm::raw_ostream& out_s, const TypeARTConfigOptio
 
 }  // namespace typeart::config
 
-#endif /* C86BA97A_734C_4A62_A56E_9E38A9E55DE6 */
+#endif /* TYPEART_OPTIONS_H */

--- a/lib/passes/typegen/TypeGenerator.h
+++ b/lib/passes/typegen/TypeGenerator.h
@@ -13,8 +13,8 @@
 #ifndef TYPEART_TYPEGENERATOR_H
 #define TYPEART_TYPEGENERATOR_H
 
-#include "typelib/TypeDatabase.h"
 #include "analysis/MemOpData.h"
+#include "typelib/TypeDatabase.h"
 #include "typelib/TypeInterface.h"
 
 #include <cstddef>

--- a/lib/passes/typegen/TypeGenerator.h
+++ b/lib/passes/typegen/TypeGenerator.h
@@ -13,7 +13,7 @@
 #ifndef TYPEART_TYPEGENERATOR_H
 #define TYPEART_TYPEGENERATOR_H
 
-#include "TypeDatabase.h"
+#include "typelib/TypeDatabase.h"
 #include "analysis/MemOpData.h"
 #include "typelib/TypeInterface.h"
 

--- a/lib/support/Configuration.h
+++ b/lib/support/Configuration.h
@@ -123,11 +123,7 @@ class Configuration {
   [[nodiscard]] virtual std::optional<OptionValue> getValue(std::string_view opt_path) const = 0;
 
   [[nodiscard]] virtual OptionValue getValueOr(std::string_view opt_path, OptionValue alt) const {
-    const auto val = getValue(opt_path);
-    if (val) {
-      return val.value();
-    }
-    return alt;
+    return getValue(opt_path).value_or(alt);
   }
 
   [[nodiscard]] virtual OptionValue operator[](std::string_view opt_path) const {

--- a/lib/support/Configuration.h
+++ b/lib/support/Configuration.h
@@ -24,26 +24,26 @@
 namespace typeart::config {
 
 struct ConfigStdArgs final {
-#define TYPEART_CONFIG_OPTION(name, path, type, def_value, description) static constexpr char name[] = path;
+#define TYPEART_CONFIG_OPTION(name, path, type, def_value, description, upper_path) static constexpr char name[] = path;
 #include "ConfigurationBaseOptions.h"
 #undef TYPEART_CONFIG_OPTION
 };
 
 struct ConfigStdArgValues final {
-#define TYPEART_CONFIG_OPTION(name, path, type, def_value, description) \
+#define TYPEART_CONFIG_OPTION(name, path, type, def_value, description, upper_path) \
   static constexpr decltype(def_value) name{def_value};
 #include "ConfigurationBaseOptions.h"
 #undef TYPEART_CONFIG_OPTION
 };
 
 struct ConfigStdArgTypes final {
-#define TYPEART_CONFIG_OPTION(name, path, type, default_value, description) using name##_ty = type;
+#define TYPEART_CONFIG_OPTION(name, path, type, default_value, description, upper_path) using name##_ty = type;
 #include "ConfigurationBaseOptions.h"
 #undef TYPEART_CONFIG_OPTION
 };
 
 struct ConfigStdArgDescriptions final {
-#define TYPEART_CONFIG_OPTION(name, path, type, default_value, description) static constexpr char name[] = description;
+#define TYPEART_CONFIG_OPTION(name, path, type, default_value, description, upper_path) static constexpr char name[] = description;
 #include "ConfigurationBaseOptions.h"
 #undef TYPEART_CONFIG_OPTION
 };

--- a/lib/support/Configuration.h
+++ b/lib/support/Configuration.h
@@ -15,6 +15,8 @@
 
 #include "support/Logger.h"
 
+#include "llvm/ADT/StringMap.h"
+
 #include <optional>
 #include <string>
 #include <string_view>
@@ -43,7 +45,8 @@ struct ConfigStdArgTypes final {
 };
 
 struct ConfigStdArgDescriptions final {
-#define TYPEART_CONFIG_OPTION(name, path, type, default_value, description, upper_path) static constexpr char name[] = description;
+#define TYPEART_CONFIG_OPTION(name, path, type, default_value, description, upper_path) \
+  static constexpr char name[] = description;
 #include "ConfigurationBaseOptions.h"
 #undef TYPEART_CONFIG_OPTION
 };
@@ -111,6 +114,9 @@ class OptionValue final {
     }
   }
 };
+
+using OptionsMap       = llvm::StringMap<OptionValue>;
+using OptOccurrenceMap = llvm::StringMap<bool>;
 
 class Configuration {
  public:

--- a/lib/support/ConfigurationBase.h
+++ b/lib/support/ConfigurationBase.h
@@ -1,0 +1,48 @@
+// TypeART library
+//
+// Copyright (c) 2017-2025 TypeART Authors
+// Distributed under the BSD 3-Clause license.
+// (See accompanying file LICENSE.txt or copy at
+// https://opensource.org/licenses/BSD-3-Clause)
+//
+// Project home: https://github.com/tudasc/TypeART
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#ifndef TYPEART_CONFIG_OPTION_BASE_H
+#define TYPEART_CONFIG_OPTION_BASE_H
+
+#include <string>
+
+namespace typeart::config {
+
+struct ConfigStdArgs final {
+#define TYPEART_CONFIG_OPTION(name, path, type, def_value, description, upper_path) static constexpr char name[] = path;
+#include "ConfigurationBaseOptions.h"
+#undef TYPEART_CONFIG_OPTION
+};
+
+struct ConfigStdArgValues final {
+#define TYPEART_CONFIG_OPTION(name, path, type, def_value, description, upper_path) \
+  static constexpr decltype(def_value) name{def_value};
+#include "ConfigurationBaseOptions.h"
+#undef TYPEART_CONFIG_OPTION
+};
+
+struct ConfigStdArgTypes final {
+#define TYPEART_CONFIG_OPTION(name, path, type, default_value, description, upper_path) using name##_ty = type;
+#include "ConfigurationBaseOptions.h"
+#undef TYPEART_CONFIG_OPTION
+};
+
+struct ConfigStdArgDescriptions final {
+#define TYPEART_CONFIG_OPTION(name, path, type, default_value, description, upper_path) \
+  static constexpr char name[] = description;
+#include "ConfigurationBaseOptions.h"
+#undef TYPEART_CONFIG_OPTION
+};
+
+}  // namespace typeart::config
+
+#endif /* TYPEART_CONFIG_OPTION_BASE_H */

--- a/lib/support/ConfigurationBaseOptions.h
+++ b/lib/support/ConfigurationBaseOptions.h
@@ -11,33 +11,37 @@
 //
 
 #ifndef TYPEART_CONFIG_OPTION
-#define TYPEART_CONFIG_OPTION(name, path, type, default_value, description)
+#define TYPEART_CONFIG_OPTION(name, path, type, default_value, description, upper_path)
 #endif
 
-TYPEART_CONFIG_OPTION(types, "types", std::string, "types.yaml", "Location of the generated type file.")
-TYPEART_CONFIG_OPTION(stats, "stats", bool, false, "Show statistics for TypeArt type pass.")
-TYPEART_CONFIG_OPTION(heap, "heap", bool, true, "Instrument heap allocation/free instructions.")
-TYPEART_CONFIG_OPTION(stack, "stack", bool, false, "Instrument stack allocations.")
-TYPEART_CONFIG_OPTION(global, "global", bool, false, "Instrument global allocations.")
+TYPEART_CONFIG_OPTION(types, "types", std::string, "types.yaml", "Location of the generated type file.", "TYPES")
+TYPEART_CONFIG_OPTION(stats, "stats", bool, false, "Show statistics for TypeArt type pass.", "STATS")
+TYPEART_CONFIG_OPTION(heap, "heap", bool, true, "Instrument heap allocation/free instructions.", "HEAP")
+TYPEART_CONFIG_OPTION(stack, "stack", bool, false, "Instrument stack allocations.", "STACK")
+TYPEART_CONFIG_OPTION(global, "global", bool, false, "Instrument global allocations.", "GLOBAL")
 TYPEART_CONFIG_OPTION(stack_lifetime, "stack-lifetime", bool, true,
-                      "Instrument lifetime.start intrinsic instead of alloca.")
+                      "Instrument lifetime.start intrinsic instead of alloca.", "STACK_LIFETIME")
 TYPEART_CONFIG_OPTION(filter, "filter", bool, false,
-                      "Filter allocas (stack/global) that are passed to relevant function calls.")
+                      "Filter allocas (stack/global) that are passed to relevant function calls.", "FILTER")
 TYPEART_CONFIG_OPTION(filter_impl, "filter-implementation", std::string, "std",
-                      "Select the call filter implementation.")
+                      "Select the call filter implementation.", "FILTER_IMPLEMENTATION")
 TYPEART_CONFIG_OPTION(filter_glob, "filter-glob", std::string, "*MPI_*",
-                      "Filter allocas based on the function name (glob) <string>.")
+                      "Filter allocas based on the function name (glob) <string>.", "FILTER_GLOB")
 TYPEART_CONFIG_OPTION(filter_glob_deep, "filter-glob-deep", std::string, "MPI_*",
                       "Filter allocas based on specific API: Values passed as void* are correlated when string matched "
-                      "and kept when correlated successfully.")
-TYPEART_CONFIG_OPTION(filter_cg_file, "filter-cg-file", std::string, "", "Location of call-graph file to use.")
-TYPEART_CONFIG_OPTION(analysis_filter_global, "analysis-filter-global", bool, true, "Filter globals of a module.")
+                      "and kept when correlated successfully.",
+                      "FILTER_GLOB_DEEP")
+TYPEART_CONFIG_OPTION(filter_cg_file, "filter-cg-file", std::string, "", "Location of call-graph file to use.",
+                      "FILTER_CG_FILE")
+TYPEART_CONFIG_OPTION(analysis_filter_global, "analysis-filter-global", bool, true, "Filter globals of a module.",
+                      "ANALYSIS_FILTER_GLOBAL")
 TYPEART_CONFIG_OPTION(analysis_filter_heap_alloc, "analysis-filter-heap-alloca", bool, false,
-                      "Filter alloca instructions that have a store from a heap allocation.")
+                      "Filter alloca instructions that have a store from a heap allocation.",
+                      "ANALYSIS_FILTER_HEAP_ALLOCA")
 TYPEART_CONFIG_OPTION(analysis_filter_pointer_alloc, "analysis-filter-pointer-alloca", bool, true,
-                      "Filter allocas of pointer types.")
+                      "Filter allocas of pointer types.", "ANALYSIS_FILTER_POINTER_ALLOCA")
 TYPEART_CONFIG_OPTION(analysis_filter_alloca_non_array, "analysis-filter-non-array-alloca", bool, false,
-                      "Filter scalar valued allocas.")
-TYPEART_CONFIG_OPTION(typegen, "typegen", std::string, "dimeta", "Select type layout generator.")
+                      "Filter scalar valued allocas.", "ANALYSIS_FILTER_NON_ARRAY_ALLOCA")
+TYPEART_CONFIG_OPTION(typegen, "typegen", std::string, "dimeta", "Select type layout generator.", "TYPEGEN")
 
 #undef TYPEART_CONFIG_OPTION

--- a/lib/support/FileConfiguration.cpp
+++ b/lib/support/FileConfiguration.cpp
@@ -53,7 +53,7 @@ class YamlFileConfiguration final : public FileOptions {
 };
 
 YamlFileConfiguration::YamlFileConfiguration(const TypeARTConfigOptions& conf_file)
-    : mapping_(config::options_to_map(conf_file)) {
+    : mapping_(helper::options_to_map(conf_file)) {
 }
 
 std::optional<typeart::config::OptionValue> YamlFileConfiguration::getValue(std::string_view opt_path) const {
@@ -72,10 +72,6 @@ std::string YamlFileConfiguration::getConfigurationAsString() const {
   return write_file_configuration_as_text(*this);
 }
 
-namespace yaml {
-TypeARTConfigOptions yaml_read_file(llvm::yaml::Input& input);
-void yaml_output_file(llvm::yaml::Output& output, TypeARTConfigOptions& config);
-}  // namespace yaml
 
 namespace compat {
 auto open_flag() {
@@ -98,7 +94,7 @@ auto open_flag() {
   }
 
   llvm::yaml::Input input_yaml(memBuffer.get()->getMemBufferRef());
-  const auto file_content = typeart::config::file::yaml::yaml_read_file(input_yaml);
+  const auto file_content = io::yaml::yaml_read_file(input_yaml);
 
   return std::make_unique<YamlFileConfiguration>(file_content);
 }
@@ -119,8 +115,8 @@ llvm::ErrorOr<bool> write_file_configuration(llvm::raw_ostream& oss, const FileO
 
   auto data = options.getConfiguration();
 
-  auto conf_file = map_to_options(options.getConfiguration());
-  yaml::yaml_output_file(out, conf_file);
+  auto conf_file = helper::map_to_options(options.getConfiguration());
+  io::yaml::yaml_output_file(out, conf_file);
 
   return true;
 }
@@ -135,89 +131,3 @@ std::string write_file_configuration_as_text(const FileOptions& file_options) {
 }
 
 }  // namespace typeart::config::file
-
-using namespace llvm::yaml;
-using namespace typeart::config::file;
-
-template <>
-struct ScalarEnumerationTraits<typeart::analysis::FilterImplementation> {
-  static void enumeration(IO& io, typeart::analysis::FilterImplementation& value) {
-    io.enumCase(value, "cg", typeart::analysis::FilterImplementation::cg);
-    io.enumCase(value, "std", typeart::analysis::FilterImplementation::standard);
-    io.enumCase(value, "none", typeart::analysis::FilterImplementation::none);
-  }
-};
-
-template <>
-struct ScalarEnumerationTraits<typeart::TypegenImplementation> {
-  static void enumeration(IO& io, typeart::TypegenImplementation& value) {
-    io.enumCase(value, "dimeta", typeart::TypegenImplementation::DIMETA);
-    io.enumCase(value, "ir", typeart::TypegenImplementation::IR);
-  }
-};
-
-template <>
-struct llvm::yaml::MappingTraits<typeart::config::TypeARTAnalysisOptions> {
-  static void mapping(IO& yml_io, typeart::config::TypeARTAnalysisOptions& info) {
-    using typeart::config::ConfigStdArgs;
-    const auto drop_prefix = [](const std::string& path, std::string_view prefix = "analysis-") {
-      llvm::StringRef prefix_less{path};
-      prefix_less.consume_front(prefix.data());
-      return prefix_less;
-    };
-    yml_io.mapOptional(drop_prefix(ConfigStdArgs::analysis_filter_global).data(), info.filter_global);
-    yml_io.mapOptional(drop_prefix(ConfigStdArgs::analysis_filter_heap_alloc).data(), info.filter_heap_alloc);
-    yml_io.mapOptional(drop_prefix(ConfigStdArgs::analysis_filter_pointer_alloc).data(), info.filter_pointer_alloc);
-    yml_io.mapOptional(drop_prefix(ConfigStdArgs::analysis_filter_alloca_non_array).data(),
-                       info.filter_alloca_non_array);
-  }
-};
-
-template <>
-struct llvm::yaml::MappingTraits<typeart::config::TypeARTCallFilterOptions> {
-  static void mapping(IO& yml_io, typeart::config::TypeARTCallFilterOptions& info) {
-    using typeart::config::ConfigStdArgs;
-    const auto drop_prefix = [](const std::string& path, std::string_view prefix = "filter-") {
-      llvm::StringRef prefix_less{path};
-      prefix_less.consume_front(prefix.data());
-      return prefix_less;
-    };
-    yml_io.mapOptional(drop_prefix(ConfigStdArgs::filter_impl).data(), info.implementation);
-    yml_io.mapOptional(drop_prefix(ConfigStdArgs::filter_glob).data(), info.glob);
-    yml_io.mapOptional(drop_prefix(ConfigStdArgs::filter_glob_deep).data(), info.glob_deep);
-    yml_io.mapOptional(drop_prefix(ConfigStdArgs::filter_cg_file).data(), info.cg_file);
-  }
-};
-
-template <>
-struct llvm::yaml::MappingTraits<typeart::config::TypeARTConfigOptions> {
-  static void mapping(IO& yml_io, typeart::config::TypeARTConfigOptions& info) {
-    using typeart::config::ConfigStdArgs;
-    yml_io.mapRequired(ConfigStdArgs::types, info.types);
-    yml_io.mapRequired(ConfigStdArgs::heap, info.heap);
-    yml_io.mapRequired(ConfigStdArgs::stack, info.stack);
-    yml_io.mapOptional(ConfigStdArgs::global, info.global);
-    yml_io.mapOptional(ConfigStdArgs::stats, info.statistics);
-    yml_io.mapOptional(ConfigStdArgs::stack_lifetime, info.stack_lifetime);
-    yml_io.mapRequired(ConfigStdArgs::typegen, info.typegen);
-    yml_io.mapRequired(ConfigStdArgs::filter, info.filter);
-    yml_io.mapOptional("call-filter", info.call_filter_configuration);
-    yml_io.mapOptional("analysis", info.analysis_configuration);
-    // yml_io.mapOptional("file-format", info.version);
-  }
-};
-
-namespace typeart::config::file::yaml {
-
-TypeARTConfigOptions yaml_read_file(llvm::yaml::Input& input) {
-  TypeARTConfigOptions file_content{};
-  input >> file_content;
-
-  return file_content;
-}
-
-void yaml_output_file(llvm::yaml::Output& output, TypeARTConfigOptions& config) {
-  output << config;
-}
-
-}  // namespace typeart::config::file::yaml

--- a/lib/support/FileConfiguration.h
+++ b/lib/support/FileConfiguration.h
@@ -18,14 +18,18 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/ErrorOr.h"
 
+namespace typeart::config {
+struct TypeARTConfigOptions;
+}
+
 namespace typeart::config::file {
 
-using FileOptionsMap = llvm::StringMap<config::OptionValue>;
+// using FileOptionsMap = llvm::StringMap<config::OptionValue>;
 
 class FileOptions : public config::Configuration {
  public:
   [[nodiscard]] std::optional<config::OptionValue> getValue(std::string_view opt_path) const override = 0;
-  [[nodiscard]] virtual FileOptionsMap getConfiguration() const                                       = 0;
+  [[nodiscard]] virtual OptionsMap getConfiguration() const                                           = 0;
   [[nodiscard]] virtual std::string getConfigurationAsString() const                                  = 0;
   ~FileOptions() override                                                                             = default;
 };
@@ -33,6 +37,8 @@ class FileOptions : public config::Configuration {
 [[maybe_unused]] llvm::ErrorOr<std::unique_ptr<FileOptions>> make_file_configuration(std::string_view file_path);
 
 [[maybe_unused]] llvm::ErrorOr<std::unique_ptr<FileOptions>> make_default_file_configuration();
+[[maybe_unused]] llvm::ErrorOr<std::unique_ptr<FileOptions>> make_from_configuration(
+    const TypeARTConfigOptions& options);
 
 [[maybe_unused]] llvm::ErrorOr<bool> write_file_configuration(llvm::raw_ostream& out_stream,
                                                               const FileOptions& file_options);

--- a/lib/support/TypeARTOptions.cpp
+++ b/lib/support/TypeARTOptions.cpp
@@ -1,0 +1,80 @@
+
+
+#include "TypeARTOptions.h"
+
+#include "support/Configuration.h"
+
+namespace typeart::config {
+
+template <typename Constructor>
+TypeARTConfigOptions construct_with(Constructor&& make_entry) {
+  TypeARTConfigOptions config;
+  make_entry(ConfigStdArgs::types, config.types);
+  make_entry(ConfigStdArgs::stats, config.statistics);
+  make_entry(ConfigStdArgs::heap, config.heap);
+  make_entry(ConfigStdArgs::global, config.global);
+  make_entry(ConfigStdArgs::stack, config.stack);
+  make_entry(ConfigStdArgs::stack_lifetime, config.stack_lifetime);
+  make_entry(ConfigStdArgs::filter, config.filter);
+  make_entry(ConfigStdArgs::filter_impl, config.call_filter_configuration.implementation);
+  make_entry(ConfigStdArgs::filter_glob, config.call_filter_configuration.glob);
+  make_entry(ConfigStdArgs::filter_glob_deep, config.call_filter_configuration.glob_deep);
+  make_entry(ConfigStdArgs::filter_cg_file, config.call_filter_configuration.cg_file);
+  make_entry(ConfigStdArgs::analysis_filter_global, config.analysis_configuration.filter_global);
+  make_entry(ConfigStdArgs::analysis_filter_heap_alloc, config.analysis_configuration.filter_heap_alloc);
+  make_entry(ConfigStdArgs::analysis_filter_pointer_alloc, config.analysis_configuration.filter_pointer_alloc);
+  make_entry(ConfigStdArgs::analysis_filter_alloca_non_array, config.analysis_configuration.filter_alloca_non_array);
+  make_entry(ConfigStdArgs::typegen, config.typegen);
+  return config;
+}
+
+TypeARTConfigOptions map_to_options(const OptionsMap& mapping) {
+  const auto make_entry = [&](std::string_view entry, auto& ref) {
+    auto key = llvm::StringRef(entry.data());
+    ref      = static_cast<typename std::remove_reference<decltype(ref)>::type>(mapping.lookup(key));
+  };
+  return construct_with(make_entry);
+}
+
+TypeARTConfigOptions config_to_options(const Configuration& configuration) {
+  const auto make_entry = [&](std::string_view entry, auto& ref) {
+    auto key = llvm::StringRef(entry.data());
+    ref      = static_cast<typename std::remove_reference<decltype(ref)>::type>(configuration[key]);
+  };
+  return construct_with(make_entry);
+}
+
+template <typename T>
+auto make_entry(std::string_view key, const T& field_value)
+    -> std::pair<llvm::StringRef, typename OptionsMap::mapped_type> {
+  if constexpr (std::is_enum_v<T>) {
+    return {key, config::OptionValue{static_cast<int>(field_value)}};
+  } else {
+    return {key, config::OptionValue{field_value}};
+  }
+};
+
+OptionsMap options_to_map(const TypeARTConfigOptions& config) {
+  OptionsMap mapping_ = {
+      make_entry(ConfigStdArgs::types, config.types),
+      make_entry(ConfigStdArgs::stats, config.statistics),
+      make_entry(ConfigStdArgs::heap, config.heap),
+      make_entry(ConfigStdArgs::global, config.global),
+      make_entry(ConfigStdArgs::stack, config.stack),
+      make_entry(ConfigStdArgs::stack_lifetime, config.stack_lifetime),
+      make_entry(ConfigStdArgs::typegen, config.typegen),
+      make_entry(ConfigStdArgs::filter, config.filter),
+      make_entry(ConfigStdArgs::filter_impl, config.call_filter_configuration.implementation),
+      make_entry(ConfigStdArgs::filter_glob, config.call_filter_configuration.glob),
+      make_entry(ConfigStdArgs::filter_glob_deep, config.call_filter_configuration.glob_deep),
+      make_entry(ConfigStdArgs::filter_cg_file, config.call_filter_configuration.cg_file),
+      make_entry(ConfigStdArgs::analysis_filter_global, config.analysis_configuration.filter_global),
+      make_entry(ConfigStdArgs::analysis_filter_heap_alloc, config.analysis_configuration.filter_heap_alloc),
+      make_entry(ConfigStdArgs::analysis_filter_pointer_alloc, config.analysis_configuration.filter_pointer_alloc),
+      make_entry(ConfigStdArgs::analysis_filter_alloca_non_array,
+                 config.analysis_configuration.filter_alloca_non_array),
+  };
+  return mapping_;
+}
+
+}  // namespace typeart::config

--- a/lib/support/TypeARTOptions.cpp
+++ b/lib/support/TypeARTOptions.cpp
@@ -2,9 +2,114 @@
 
 #include "TypeARTOptions.h"
 
+#include "FileConfiguration.h"
 #include "support/Configuration.h"
 
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/YAMLTraits.h"
+
+using namespace llvm::yaml;
+using namespace typeart::config::file;
+
+template <>
+struct ScalarEnumerationTraits<typeart::analysis::FilterImplementation> {
+  static void enumeration(IO& io, typeart::analysis::FilterImplementation& value) {
+    io.enumCase(value, "cg", typeart::analysis::FilterImplementation::cg);
+    io.enumCase(value, "std", typeart::analysis::FilterImplementation::standard);
+    io.enumCase(value, "none", typeart::analysis::FilterImplementation::none);
+  }
+};
+
+template <>
+struct ScalarEnumerationTraits<typeart::TypegenImplementation> {
+  static void enumeration(IO& io, typeart::TypegenImplementation& value) {
+    io.enumCase(value, "dimeta", typeart::TypegenImplementation::DIMETA);
+    io.enumCase(value, "ir", typeart::TypegenImplementation::IR);
+  }
+};
+
+template <>
+struct llvm::yaml::MappingTraits<typeart::config::TypeARTAnalysisOptions> {
+  static void mapping(IO& yml_io, typeart::config::TypeARTAnalysisOptions& info) {
+    using typeart::config::ConfigStdArgs;
+    const auto drop_prefix = [](const std::string& path, std::string_view prefix = "analysis-") {
+      llvm::StringRef prefix_less{path};
+      prefix_less.consume_front(prefix.data());
+      return prefix_less;
+    };
+    yml_io.mapOptional(drop_prefix(ConfigStdArgs::analysis_filter_global).data(), info.filter_global);
+    yml_io.mapOptional(drop_prefix(ConfigStdArgs::analysis_filter_heap_alloc).data(), info.filter_heap_alloc);
+    yml_io.mapOptional(drop_prefix(ConfigStdArgs::analysis_filter_pointer_alloc).data(), info.filter_pointer_alloc);
+    yml_io.mapOptional(drop_prefix(ConfigStdArgs::analysis_filter_alloca_non_array).data(),
+                       info.filter_alloca_non_array);
+  }
+};
+
+template <>
+struct llvm::yaml::MappingTraits<typeart::config::TypeARTCallFilterOptions> {
+  static void mapping(IO& yml_io, typeart::config::TypeARTCallFilterOptions& info) {
+    using typeart::config::ConfigStdArgs;
+    const auto drop_prefix = [](const std::string& path, std::string_view prefix = "filter-") {
+      llvm::StringRef prefix_less{path};
+      prefix_less.consume_front(prefix.data());
+      return prefix_less;
+    };
+    yml_io.mapOptional(drop_prefix(ConfigStdArgs::filter_impl).data(), info.implementation);
+    yml_io.mapOptional(drop_prefix(ConfigStdArgs::filter_glob).data(), info.glob);
+    yml_io.mapOptional(drop_prefix(ConfigStdArgs::filter_glob_deep).data(), info.glob_deep);
+    yml_io.mapOptional(drop_prefix(ConfigStdArgs::filter_cg_file).data(), info.cg_file);
+  }
+};
+
+template <>
+struct llvm::yaml::MappingTraits<typeart::config::TypeARTConfigOptions> {
+  static void mapping(IO& yml_io, typeart::config::TypeARTConfigOptions& info) {
+    using typeart::config::ConfigStdArgs;
+    yml_io.mapRequired(ConfigStdArgs::types, info.types);
+    yml_io.mapRequired(ConfigStdArgs::heap, info.heap);
+    yml_io.mapRequired(ConfigStdArgs::stack, info.stack);
+    yml_io.mapOptional(ConfigStdArgs::global, info.global);
+    yml_io.mapOptional(ConfigStdArgs::stats, info.statistics);
+    yml_io.mapOptional(ConfigStdArgs::stack_lifetime, info.stack_lifetime);
+    yml_io.mapRequired(ConfigStdArgs::typegen, info.typegen);
+    yml_io.mapRequired(ConfigStdArgs::filter, info.filter);
+    yml_io.mapOptional("call-filter", info.filter_config);
+    yml_io.mapOptional("analysis", info.analysis_config);
+    // yml_io.mapOptional("file-format", info.version);
+  }
+};
+
+namespace typeart::config::io::yaml {
+
+TypeARTConfigOptions yaml_read_file(llvm::yaml::Input& input) {
+  TypeARTConfigOptions file_content{};
+  input >> file_content;
+
+  return file_content;
+}
+
+void yaml_output_file(llvm::yaml::Output& output, const TypeARTConfigOptions& config) {
+  output << const_cast<TypeARTConfigOptions&>(config);
+}
+
+}  // namespace typeart::config::io::yaml
+
 namespace typeart::config {
+  
+llvm::raw_ostream& operator<<(llvm::raw_ostream& out_stream, const TypeARTConfigOptions& options) {
+  std::string config_text;
+  llvm::raw_string_ostream sstream(config_text);
+  llvm::yaml::Output out(sstream);
+  io::yaml::yaml_output_file(out, options);
+  out_stream.flush();
+  out_stream << sstream.str();
+  return out_stream;
+}
+
+namespace helper {
 
 template <typename Constructor>
 TypeARTConfigOptions construct_with(Constructor&& make_entry) {
@@ -16,14 +121,14 @@ TypeARTConfigOptions construct_with(Constructor&& make_entry) {
   make_entry(ConfigStdArgs::stack, config.stack);
   make_entry(ConfigStdArgs::stack_lifetime, config.stack_lifetime);
   make_entry(ConfigStdArgs::filter, config.filter);
-  make_entry(ConfigStdArgs::filter_impl, config.call_filter_configuration.implementation);
-  make_entry(ConfigStdArgs::filter_glob, config.call_filter_configuration.glob);
-  make_entry(ConfigStdArgs::filter_glob_deep, config.call_filter_configuration.glob_deep);
-  make_entry(ConfigStdArgs::filter_cg_file, config.call_filter_configuration.cg_file);
-  make_entry(ConfigStdArgs::analysis_filter_global, config.analysis_configuration.filter_global);
-  make_entry(ConfigStdArgs::analysis_filter_heap_alloc, config.analysis_configuration.filter_heap_alloc);
-  make_entry(ConfigStdArgs::analysis_filter_pointer_alloc, config.analysis_configuration.filter_pointer_alloc);
-  make_entry(ConfigStdArgs::analysis_filter_alloca_non_array, config.analysis_configuration.filter_alloca_non_array);
+  make_entry(ConfigStdArgs::filter_impl, config.filter_config.implementation);
+  make_entry(ConfigStdArgs::filter_glob, config.filter_config.glob);
+  make_entry(ConfigStdArgs::filter_glob_deep, config.filter_config.glob_deep);
+  make_entry(ConfigStdArgs::filter_cg_file, config.filter_config.cg_file);
+  make_entry(ConfigStdArgs::analysis_filter_global, config.analysis_config.filter_global);
+  make_entry(ConfigStdArgs::analysis_filter_heap_alloc, config.analysis_config.filter_heap_alloc);
+  make_entry(ConfigStdArgs::analysis_filter_pointer_alloc, config.analysis_config.filter_pointer_alloc);
+  make_entry(ConfigStdArgs::analysis_filter_alloca_non_array, config.analysis_config.filter_alloca_non_array);
   make_entry(ConfigStdArgs::typegen, config.typegen);
   return config;
 }
@@ -64,17 +169,18 @@ OptionsMap options_to_map(const TypeARTConfigOptions& config) {
       make_entry(ConfigStdArgs::stack_lifetime, config.stack_lifetime),
       make_entry(ConfigStdArgs::typegen, config.typegen),
       make_entry(ConfigStdArgs::filter, config.filter),
-      make_entry(ConfigStdArgs::filter_impl, config.call_filter_configuration.implementation),
-      make_entry(ConfigStdArgs::filter_glob, config.call_filter_configuration.glob),
-      make_entry(ConfigStdArgs::filter_glob_deep, config.call_filter_configuration.glob_deep),
-      make_entry(ConfigStdArgs::filter_cg_file, config.call_filter_configuration.cg_file),
-      make_entry(ConfigStdArgs::analysis_filter_global, config.analysis_configuration.filter_global),
-      make_entry(ConfigStdArgs::analysis_filter_heap_alloc, config.analysis_configuration.filter_heap_alloc),
-      make_entry(ConfigStdArgs::analysis_filter_pointer_alloc, config.analysis_configuration.filter_pointer_alloc),
-      make_entry(ConfigStdArgs::analysis_filter_alloca_non_array,
-                 config.analysis_configuration.filter_alloca_non_array),
+      make_entry(ConfigStdArgs::filter_impl, config.filter_config.implementation),
+      make_entry(ConfigStdArgs::filter_glob, config.filter_config.glob),
+      make_entry(ConfigStdArgs::filter_glob_deep, config.filter_config.glob_deep),
+      make_entry(ConfigStdArgs::filter_cg_file, config.filter_config.cg_file),
+      make_entry(ConfigStdArgs::analysis_filter_global, config.analysis_config.filter_global),
+      make_entry(ConfigStdArgs::analysis_filter_heap_alloc, config.analysis_config.filter_heap_alloc),
+      make_entry(ConfigStdArgs::analysis_filter_pointer_alloc, config.analysis_config.filter_pointer_alloc),
+      make_entry(ConfigStdArgs::analysis_filter_alloca_non_array, config.analysis_config.filter_alloca_non_array),
   };
   return mapping_;
 }
+
+}  // namespace helper
 
 }  // namespace typeart::config

--- a/lib/support/TypeARTOptions.h
+++ b/lib/support/TypeARTOptions.h
@@ -1,0 +1,50 @@
+#ifndef C86BA97A_734C_4A62_A56E_9E38A9E55DE6
+#define C86BA97A_734C_4A62_A56E_9E38A9E55DE6
+
+#include "../passes/analysis/MemInstFinder.h"
+#include "../passes/typegen/TypeGenerator.h"
+
+#include "support/Configuration.h"
+
+namespace typeart::config {
+
+using typeart::analysis::FilterImplementation;
+using typeart::config::ConfigStdArgValues;
+
+struct TypeARTCallFilterOptions {
+  FilterImplementation implementation{FilterImplementation::standard};
+  std::string glob{ConfigStdArgValues::filter_glob};
+  std::string glob_deep{ConfigStdArgValues::filter_glob_deep};
+  std::string cg_file{ConfigStdArgValues::filter_cg_file};
+};
+
+struct TypeARTAnalysisOptions {
+  bool filter_global{ConfigStdArgValues::analysis_filter_global};
+  bool filter_heap_alloc{ConfigStdArgValues::analysis_filter_heap_alloc};
+  bool filter_pointer_alloc{ConfigStdArgValues::analysis_filter_pointer_alloc};
+  bool filter_alloca_non_array{ConfigStdArgValues::analysis_filter_alloca_non_array};
+};
+
+struct TypeARTConfigOptions {
+  std::string types{ConfigStdArgValues::types};
+  bool heap{ConfigStdArgValues::heap};
+  bool stack{ConfigStdArgValues::stack};
+  bool global{ConfigStdArgValues::global};
+  bool statistics{ConfigStdArgValues::stats};
+  bool stack_lifetime{ConfigStdArgValues::stack_lifetime};
+  TypegenImplementation typegen{TypegenImplementation::DIMETA};
+  bool filter{false};
+
+  TypeARTCallFilterOptions call_filter_configuration{};
+  TypeARTAnalysisOptions analysis_configuration{};
+};
+
+TypeARTConfigOptions map_to_options(const OptionsMap&);
+
+TypeARTConfigOptions config_to_options(const Configuration&);
+
+OptionsMap options_to_map(const TypeARTConfigOptions&);
+
+}  // namespace typeart::config
+
+#endif /* C86BA97A_734C_4A62_A56E_9E38A9E55DE6 */

--- a/lib/support/TypeARTOptions.h
+++ b/lib/support/TypeARTOptions.h
@@ -3,8 +3,12 @@
 
 #include "../passes/analysis/MemInstFinder.h"
 #include "../passes/typegen/TypeGenerator.h"
-
 #include "support/Configuration.h"
+
+namespace llvm::yaml {
+class Input;
+class Output;
+}  // namespace llvm::yaml
 
 namespace typeart::config {
 
@@ -35,15 +39,27 @@ struct TypeARTConfigOptions {
   TypegenImplementation typegen{TypegenImplementation::DIMETA};
   bool filter{false};
 
-  TypeARTCallFilterOptions call_filter_configuration{};
-  TypeARTAnalysisOptions analysis_configuration{};
+  TypeARTCallFilterOptions filter_config{};
+  TypeARTAnalysisOptions analysis_config{};
 };
 
+namespace helper {
 TypeARTConfigOptions map_to_options(const OptionsMap&);
 
 TypeARTConfigOptions config_to_options(const Configuration&);
 
 OptionsMap options_to_map(const TypeARTConfigOptions&);
+}  // namespace helper
+
+namespace io::yaml {
+
+TypeARTConfigOptions yaml_read_file(llvm::yaml::Input& input);
+
+void yaml_output_file(llvm::yaml::Output& output, const TypeARTConfigOptions& config);
+
+}  // namespace io::yaml
+
+llvm::raw_ostream& operator<<(llvm::raw_ostream& out_s, const TypeARTConfigOptions& options);
 
 }  // namespace typeart::config
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,8 @@ typeart_find_llvm_progs(TYPEART_LIT_EXEC
   ABORT_IF_MISSING
 )
 
+# add_subdirectory(compat)
+
 macro(pythonize_bool truth_var var)
   if(${truth_var})
     set(${var} True)
@@ -53,8 +55,11 @@ function(typeart_configure_lit_site input output)
     set(TYPEART_COVERAGE True)
   endif()
 
+  set(TYPEART_USE_NEW_PM True)
+  # set(TYPEART_OPT_EXEC "${CMAKE_BINARY_DIR}/test/compat/opt-shim")
   if(${LLVM_VERSION_MAJOR} VERSION_EQUAL "14")
     set(TYPEART_OPT_ARGS "-enable-new-pm=0")
+    set(TYPEART_USE_NEW_PM False)
   endif()
 
   set(LIT_SITE_CFG_IN_HEADER

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -43,6 +43,7 @@ config.coverage=@TYPEART_COVERAGE@
 config.python_interp = "@Python3_EXECUTABLE@"
 
 config.llvm_version = @LLVM_VERSION_MAJOR@
+config.new_pm = @TYPEART_USE_NEW_PM@
 
 # Let the main config do the real work.
 config.loaded_site_config = True

--- a/test/lulesh/Makefile
+++ b/test/lulesh/Makefile
@@ -24,7 +24,7 @@ OBJECTS2.0 = $(SOURCES2.0:.cc=.o)
 CXXFLAGS = -g -I. -Wall
 LDFLAGS = -g -O3
 
-PASSES=-load ${TYPEART_LIBPATH}/passes/analysis/meminstfinderpass.so -load ${TYPEART_LIBPATH}/passes/typeartpass.so -typeart-stats
+PASSES=-load ${TYPEART_LIBPATH}/passes/analysis/meminstfinderpass.so -load ${TYPEART_LIBPATH}/passes/typeartpass.so --typeart-stats
 CALL_FILTER=--typeart-filter --typeart-filter-implementation=default
 
 ifeq ($(TSAN), yes)

--- a/test/pass/arrays/01_simple_array.c
+++ b/test/pass/arrays/01_simple_array.c
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack --typeart-stack-lifetime=false -S 2>&1 | %filecheck %s --check-prefixes CHECK,ALLOC
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-stack-lifetime=false -S 2>&1 | %filecheck %s --check-prefixes CHECK,ALLOC
 // clang-format on
 void test() {
   int a[100];

--- a/test/pass/arrays/02_array_to_pointer.c
+++ b/test/pass/arrays/02_array_to_pointer.c
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack --typeart-analysis-filter-pointer-alloca=false --typeart-stack-lifetime=false -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-analysis-filter-pointer-alloca=false --typeart-stack-lifetime=false -S 2>&1 | %filecheck %s
 // clang-format on
 void test() {
   int a[100];

--- a/test/pass/arrays/03_multidim_array.c
+++ b/test/pass/arrays/03_multidim_array.c
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true -S 2>&1 | %filecheck %s
 // clang-format on
 void test() {
   const int n = 64;

--- a/test/pass/arrays/04_vla.c
+++ b/test/pass/arrays/04_vla.c
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack --typeart-analysis-filter-non-array-alloca=true -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-analysis-filter-non-array-alloca=true -S 2>&1 | %filecheck %s
 // clang-format on
 void test(int n) {
   int a[n];

--- a/test/pass/arrays/05_vector.c
+++ b/test/pass/arrays/05_vector.c
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %remove %tu_yaml && %c-to-llvm %s | %apply-typeart --typeart-stack -S 2>&1 | %filecheck %s
+// RUN: %remove %tu_yaml && %c-to-llvm %s | %apply-typeart --typeart-stack=true -S 2>&1 | %filecheck %s
 // clang-format on
 
 typedef float float2 __attribute__((ext_vector_type(2)));

--- a/test/pass/arrays/07_avx.c
+++ b/test/pass/arrays/07_avx.c
@@ -1,5 +1,6 @@
+// clang-format off
 // RUN: %remove %tu_yaml && %c-to-llvm -mavx %s | %opt -O2 -S | %apply-typeart --typeart-stack=true -S 2>&1 | %filecheck %s
-
+// clang-format on
 #include <immintrin.h>
 
 __m256 vec_result;

--- a/test/pass/arrays/07_avx.c
+++ b/test/pass/arrays/07_avx.c
@@ -1,4 +1,4 @@
-// RUN: %remove %tu_yaml && %c-to-llvm -mavx %s | %opt -O2 -S | %apply-typeart --typeart-stack -S 2>&1 | %filecheck %s
+// RUN: %remove %tu_yaml && %c-to-llvm -mavx %s | %opt -O2 -S | %apply-typeart --typeart-stack=true -S 2>&1 | %filecheck %s
 
 #include <immintrin.h>
 

--- a/test/pass/filter/00_ignore_ta_memops.c
+++ b/test/pass/filter/00_ignore_ta_memops.c
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart -S | %apply-typeart --typeart-stack --typeart-heap=false --typeart-filter -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart -S | %apply-typeart --typeart-stack=true --typeart-heap=false --typeart-filter=true -S 2>&1 | %filecheck %s
 // clang-format on
 
 #include <stdlib.h>

--- a/test/pass/filter/01_alloca.llin
+++ b/test/pass/filter/01_alloca.llin
@@ -1,5 +1,5 @@
-; RUN: cat %s | %apply-typeart --typeart-stack --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s
-; RUN: cat %s | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s -check-prefix=CHECK-FILTER-EXP
+; RUN: cat %s | %apply-typeart --typeart-stack=true --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s
+; RUN: cat %s | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s -check-prefix=CHECK-FILTER-EXP
 
 ; REQUIRES: !dimeta
 

--- a/test/pass/filter/02_recursion.c
+++ b/test/pass/filter/02_recursion.c
@@ -1,6 +1,6 @@
 // Template for recursion.ll.in
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s
 // clang-format on
 void bar(int* x) {
 }

--- a/test/pass/filter/03_globals.c
+++ b/test/pass/filter/03_globals.c
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack --typeart-filter  -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-filter=true  -S 2>&1 | %filecheck %s
 // clang-format on
 
 int a;

--- a/test/pass/filter/04_cg.c
+++ b/test/pass/filter/04_cg.c
@@ -1,6 +1,6 @@
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack --typeart-filter --typeart-filter-implementation=cg --typeart-filter-cg-file=%p/04_cg.ipcg -S 2>&1 | %filecheck %s
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s --check-prefix=CHECK-default
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-filter-implementation=cg --typeart-filter-cg-file=%p/04_cg.ipcg -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s --check-prefix=CHECK-default
 // clang-format on
 
 extern void bar(int* ptr);  // reaches MPI, see 04_cg.ipcg

--- a/test/pass/filter/05_correlate_sig.c
+++ b/test/pass/filter/05_correlate_sig.c
@@ -1,6 +1,6 @@
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s --check-prefix=CHECK-exp-default
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack --typeart-filter --typeart-filter-implementation=cg --typeart-filter-cg-file=%p/05_cg.ipcg -S 2>&1 | %filecheck %s --check-prefix=CHECK-exp-cg
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s --check-prefix=CHECK-exp-default
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-filter-implementation=cg --typeart-filter-cg-file=%p/05_cg.ipcg -S 2>&1 | %filecheck %s --check-prefix=CHECK-exp-cg
 // clang-format on
 
 extern void MPI_Mock(int, int, int);

--- a/test/pass/filter/06_empty.c
+++ b/test/pass/filter/06_empty.c
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack --typeart-filter  -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-filter=true  -S 2>&1 | %filecheck %s
 // clang-format on
 
 extern int d;

--- a/test/pass/filter/07_lulesh_mock.cpp
+++ b/test/pass/filter/07_lulesh_mock.cpp
@@ -1,6 +1,6 @@
 // clang-format off
-// RUN: %c-to-llvm -fno-discard-value-names %s | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s --check-prefix=CHECK-exp-default
-// RUN: %c-to-llvm -fno-discard-value-names %s | %opt -O3 -S | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s --check-prefix=CHECK-exp-default-opt
+// RUN: %c-to-llvm -fno-discard-value-names %s | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s --check-prefix=CHECK-exp-default
+// RUN: %c-to-llvm -fno-discard-value-names %s | %opt -O3 -S | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s --check-prefix=CHECK-exp-default-opt
 // clang-format on
 
 using Real_t = double;

--- a/test/pass/filter/08_amg_box_algebra_mock.c
+++ b/test/pass/filter/08_amg_box_algebra_mock.c
@@ -1,6 +1,6 @@
 // This file tests for an specific endless recursion in the filter implementations w.r.t. following store targets
 // RUN: %c-to-llvm -fno-discard-value-names %s | %opt -O3 -S \
-// RUN: | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 \
+// RUN: | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 \
 // RUN: | %filecheck %s --check-prefix=CHECK-exp-default-opt
 
 // CHECK-exp-default-opt: TypeArtPass [Heap & Stack]

--- a/test/pass/filter/09_milc_gauge_stuff_mock.c
+++ b/test/pass/filter/09_milc_gauge_stuff_mock.c
@@ -1,6 +1,6 @@
 // This file tests for an specific endless recursion in the filter implementations w.r.t. following store targets
 // RUN: %c-to-llvm -fno-discard-value-names %s | %opt -O3 -S \
-// RUN: | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 \
+// RUN: | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 \
 // RUN: | %filecheck %s --check-prefix=CHECK-exp-default-opt
 
 // CHECK-exp-default-opt: TypeArtPass [Heap & Stack]

--- a/test/pass/filter/10_omp_empty.c
+++ b/test/pass/filter/10_omp_empty.c
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter  -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true  -S 2>&1 | %filecheck %s
 // REQUIRES: openmp
 // clang-format on
 

--- a/test/pass/filter/11_omp_mpi_simple.c
+++ b/test/pass/filter/11_omp_mpi_simple.c
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s --check-prefix CHECK-alloca-pointer
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s --check-prefix CHECK-alloca-pointer
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s
 
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=true -S 2>&1 | %filecheck %s --check-prefix CHECK-alloca-pointer
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=true -S 2>&1 | %filecheck %s --check-prefix CHECK-alloca-pointer
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=true -S 2>&1 | %filecheck %s --check-prefix CHECK-alloca-pointer
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=true -S 2>&1 | %filecheck %s --check-prefix CHECK-alloca-pointer
 // clang-format on
 
 // REQUIRES: openmp

--- a/test/pass/filter/12_omp_correlate.c
+++ b/test/pass/filter/12_omp_correlate.c
@@ -1,11 +1,11 @@
 // clang-format off
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s --check-prefix=CHECK-opt
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter --typeart-filter-implementation=cg --typeart-filter-cg-file=%p/05_cg.ipcg --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s --check-prefix=CHECK-exp-cg
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s --check-prefix=CHECK-opt
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-filter-implementation=cg --typeart-filter-cg-file=%p/05_cg.ipcg --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s --check-prefix=CHECK-exp-cg
 
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=false -S | %filecheck %s --check-prefix=check-inst
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=false -S | %filecheck %s --check-prefix=check-inst
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter --typeart-filter-implementation=cg --typeart-filter-cg-file=%p/05_cg.ipcg --typeart-analysis-filter-pointer-alloca=false -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=false -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=false -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-filter-implementation=cg --typeart-filter-cg-file=%p/05_cg.ipcg --typeart-analysis-filter-pointer-alloca=false -S | %filecheck %s --check-prefix=check-inst
 // REQUIRES: openmp
 // clang-format on
 

--- a/test/pass/filter/13_omp_loops.c
+++ b/test/pass/filter/13_omp_loops.c
@@ -1,11 +1,11 @@
 // clang-format off
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter --typeart-filter-implementation=cg --typeart-filter-cg-file=%p/05_cg.ipcg -S 2>&1
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-filter-implementation=cg --typeart-filter-cg-file=%p/05_cg.ipcg -S 2>&1
 
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter -S | %filecheck %s --check-prefix=check-inst
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter -S | %filecheck %s --check-prefix=check-inst
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter --typeart-filter-implementation=cg --typeart-filter-cg-file=%p/05_cg.ipcg -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-filter-implementation=cg --typeart-filter-cg-file=%p/05_cg.ipcg -S | %filecheck %s --check-prefix=check-inst
 // REQUIRES: openmp
 // clang-format on
 

--- a/test/pass/filter/14_omp_nested.c
+++ b/test/pass/filter/14_omp_nested.c
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s
 
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter -S | %filecheck %s --check-prefix=check-inst
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefix=check-inst
 // REQUIRES: openmp
 // clang-format on
 extern void MPI_call(void*);

--- a/test/pass/filter/15_omp_task.c
+++ b/test/pass/filter/15_omp_task.c
@@ -1,8 +1,8 @@
 // clang-format off
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s --check-prefix=CHECK-opt
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s --check-prefix=CHECK-opt
 
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefix=check-inst
 // REQUIRES: openmp
 // clang-format on
 extern void MPI_call(void*);

--- a/test/pass/filter/16_omp_reduction.c
+++ b/test/pass/filter/16_omp_reduction.c
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s
 
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter -S | %filecheck %s --check-prefix=check-inst
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefix=check-inst
 // REQUIRES: openmp
 // clang-format on
 

--- a/test/pass/filter/17_omp_sharing_semantics.c
+++ b/test/pass/filter/17_omp_sharing_semantics.c
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s
 
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter -S | %filecheck %s --check-prefix=check-inst
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefix=check-inst
 
 // REQUIRES: openmp && !dimeta
 

--- a/test/pass/filter/18_omp_last_priv_nested.c
+++ b/test/pass/filter/18_omp_last_priv_nested.c
@@ -1,7 +1,7 @@
 // clang-format off
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s
 
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=false -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=false -S | %filecheck %s --check-prefix=check-inst
 // REQUIRES: openmp && !dimeta
 // clang-format on
 

--- a/test/pass/filter/19_omp_first_priv_nested.c
+++ b/test/pass/filter/19_omp_first_priv_nested.c
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s
 
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter -S | %filecheck %s --check-prefix=check-inst
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefix=check-inst
 // REQUIRES: openmp
 // clang-format on
 

--- a/test/pass/filter/20_omp_priv_combi_nested.c
+++ b/test/pass/filter/20_omp_priv_combi_nested.c
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s --check-prefix=check-opt
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s --check-prefix=check-opt
 
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=false -S | %filecheck %s --check-prefix=check-inst
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter --typeart-analysis-filter-pointer-alloca=false -S | %filecheck %s --check-prefix=check-opt-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=false -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true --typeart-analysis-filter-pointer-alloca=false -S | %filecheck %s --check-prefix=check-opt-inst
 // REQUIRES: openmp && !dimeta
 // clang-format on
 

--- a/test/pass/filter/21_omp_task_struct.c
+++ b/test/pass/filter/21_omp_task_struct.c
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s --check-prefix=CHECK-opt
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s --check-prefix=CHECK-opt
 
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack --typeart-filter -S | %filecheck %s --check-prefix=check-inst
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack --typeart-filter -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefix=check-inst
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefix=check-inst
 // REQUIRES: openmp
 // clang-format on
 extern void MPI_call(void*);

--- a/test/pass/filter/22_omp_ident_offset.llin
+++ b/test/pass/filter/22_omp_ident_offset.llin
@@ -1,4 +1,4 @@
-; RUN: cat %s | %apply-typeart --typeart-stack --typeart-filter -S 2>&1 | %filecheck %s
+; RUN: cat %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s
 
 ; REQUIRES: !dimeta
 

--- a/test/pass/filter/23_pointer_alloca.c
+++ b/test/pass/filter/23_pointer_alloca.c
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack --typeart-analysis-filter-pointer-alloca=true -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-analysis-filter-pointer-alloca=true -S 2>&1 | %filecheck %s
 // clang-format on
 
 int main(int argc, char** argv) {

--- a/test/pass/global/01_globals.c
+++ b/test/pass/global/01_globals.c
@@ -1,4 +1,4 @@
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-global -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s
 
 int global;
 int global_2 = 0;

--- a/test/pass/global/02_globals.cpp
+++ b/test/pass/global/02_globals.cpp
@@ -1,4 +1,4 @@
-// RUN: %cpp-to-llvm %s | %apply-typeart --typeart-global -S 2>&1 | %filecheck %s
+// RUN: %cpp-to-llvm %s | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s
 
 int global;
 int global_2 = 0;

--- a/test/pass/global/03_milc_setup_readin_mock.llin
+++ b/test/pass/global/03_milc_setup_readin_mock.llin
@@ -1,4 +1,4 @@
-; RUN: cat %s | %apply-typeart --typeart-global -S 2>&1 | %filecheck %s
+; RUN: cat %s | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s
 
 ; REQUIRES: !dimeta
 

--- a/test/pass/global/04_const_char.c
+++ b/test/pass/global/04_const_char.c
@@ -1,4 +1,4 @@
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-global -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s
 
 // REQUIRES: !dimeta
 

--- a/test/pass/global/05_asan.c
+++ b/test/pass/global/05_asan.c
@@ -1,4 +1,4 @@
-// RUN: %c-to-llvm %s -fsanitize=address | %apply-typeart --typeart-global -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s -fsanitize=address | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s
 
 // REQUIRES: asan
 

--- a/test/pass/global/06_coverage.c
+++ b/test/pass/global/06_coverage.c
@@ -1,4 +1,4 @@
-// RUN: %c-to-llvm --coverage %s | %apply-typeart --typeart-global -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm --coverage %s | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s
 
 int global;
 int global_2 = 0;

--- a/test/pass/global/07_coverage_llvm.c
+++ b/test/pass/global/07_coverage_llvm.c
@@ -1,4 +1,4 @@
-// RUN: %c-to-llvm -fprofile-instr-generate -fcoverage-mapping %s | %apply-typeart --typeart-global -S 2>&1 \
+// RUN: %c-to-llvm -fprofile-instr-generate -fcoverage-mapping %s | %apply-typeart --typeart-global=true -S 2>&1 \
 // RUN: | %filecheck %s
 
 int global;

--- a/test/pass/global/08_global_skip.c
+++ b/test/pass/global/08_global_skip.c
@@ -1,6 +1,6 @@
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-global -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s
 
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack --typeart-global=false -S 2>&1 \
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-global=false -S 2>&1 \
 // RUN: | %filecheck %s --check-prefix CHECK-SKIP
 
 int global;

--- a/test/pass/misc/01_MemInstFinder_Args.c
+++ b/test/pass/misc/01_MemInstFinder_Args.c
@@ -1,7 +1,7 @@
 // clang-format off
 // Sanity check for arg names
 // RUN: %c-to-llvm %s | %opt -load %transform_pass -typeart \
-// RUN: --typeart-filter \
+// RUN: --typeart-filter=true \
 // RUN: --typeart-filter-implementation=none \
 // RUN: --typeart-filter-glob=MPI1 \
 // RUN: --typeart-filter-glob-deep=MPI2 \

--- a/test/pass/misc/02_TypeArtPass_Args.c
+++ b/test/pass/misc/02_TypeArtPass_Args.c
@@ -1,11 +1,11 @@
 // clang-format off
 // Sanity check for arg names
 // RUN: %c-to-llvm %s | %opt -load %transform_pass -typeart \
-// RUN: -typeart-stats \
+// RUN: --typeart-stats \
 // RUN: --typeart-heap=true \
 // RUN: --typeart-stack=true \
 // RUN: --typeart-global=false \
-// RUN: -typeart-types=typeart_types.yaml
+// RUN: --typeart-types=typeart_types.yaml
 // clang-format on
 
 void foo() {

--- a/test/pass/misc/03_make_mismatch_callback.c
+++ b/test/pass/misc/03_make_mismatch_callback.c
@@ -1,4 +1,4 @@
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true -S 2>&1 | %filecheck %s
 // XFAIL: *
 
 #include <stddef.h>

--- a/test/pass/misc/04_make_callback_match.c
+++ b/test/pass/misc/04_make_callback_match.c
@@ -1,4 +1,4 @@
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true -S 2>&1 | %filecheck %s
 
 void __typeart_leave_scope(int alloca_count);
 

--- a/test/pass/misc/05_make_all_callbacks.c
+++ b/test/pass/misc/05_make_all_callbacks.c
@@ -1,4 +1,4 @@
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true -S 2>&1 | %filecheck %s
 
 #include "../../../lib/runtime/CallbackInterface.h"
 

--- a/test/pass/misc/06_unknown_type.llin
+++ b/test/pass/misc/06_unknown_type.llin
@@ -1,4 +1,4 @@
-; RUN: cat %s | %apply-typeart --typeart-stack --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s
+; RUN: cat %s | %apply-typeart --typeart-stack=true --typeart-analysis-filter-pointer-alloca=false -S 2>&1 | %filecheck %s
 
 define dso_local i32 @main() #0 {
 ; CHECK-NOT: call @__typeart_alloc_stack

--- a/test/pass/misc/07_config_file.c
+++ b/test/pass/misc/07_config_file.c
@@ -5,11 +5,11 @@ void test() {
   int* p = (int*)malloc(42 * sizeof(int));
 }
 
-// CHECK: types:           types_config.yaml
+// CHECK: types:           {{.*}}
 // CHECK-NEXT:  heap:            false
 // CHECK-NEXT:  stack:           true
 // CHECK-NEXT:  global:          false
-// CHECK-NEXT:  stats:           false
+// CHECK-NEXT:  stats:           {{.*}}
 // CHECK-NEXT:  stack-lifetime:  false
 // CHECK-NEXT:  typegen:         dimeta
 // CHECK-NEXT:  filter:          false

--- a/test/pass/misc/07_config_file.c
+++ b/test/pass/misc/07_config_file.c
@@ -1,4 +1,4 @@
-// RUN: %c-to-llvm %s | %apply-typeart -typeart-config=%S/07_typeart_config_stack.yml 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-config=%S/07_typeart_config_stack.yml 2>&1 | %filecheck %s
 
 #include <stdlib.h>
 void test() {
@@ -11,7 +11,7 @@ void test() {
 // CHECK-NEXT:  global:          false
 // CHECK-NEXT:  stats:           {{.*}}
 // CHECK-NEXT:  stack-lifetime:  false
-// CHECK-NEXT:  typegen:         dimeta
+// CHECK-NEXT:  typegen:         {{dimeta|ir}}
 // CHECK-NEXT:  filter:          false
 // CHECK-NEXT:  call-filter:
 // CHECK-NEXT:    implementation:  std

--- a/test/pass/misc/08_config_file_default.c
+++ b/test/pass/misc/08_config_file_default.c
@@ -2,11 +2,11 @@
 
 // CHECK-NOT: {{(Error|Fatal)}}
 
-// CHECK: types:           types.yaml
+// CHECK: types:           {{.*}}.yaml
 // CHECK-NEXT: heap:            true
 // CHECK-NEXT: stack:           false
 // CHECK-NEXT: global:          false
-// CHECK-NEXT: stats:           false
+// CHECK-NEXT: stats:           true
 // CHECK-NEXT: stack-lifetime:  true
 // CHECK-NEXT: typegen:         dimeta
 // CHECK-NEXT: filter:          false

--- a/test/pass/misc/08_config_file_default.c
+++ b/test/pass/misc/08_config_file_default.c
@@ -8,7 +8,7 @@
 // CHECK-NEXT: global:          false
 // CHECK-NEXT: stats:           true
 // CHECK-NEXT: stack-lifetime:  true
-// CHECK-NEXT: typegen:         dimeta
+// CHECK-NEXT: typegen:         {{dimeta|ir}}
 // CHECK-NEXT: filter:          false
 // CHECK-NEXT: call-filter:
 // CHECK-NEXT:   implementation:  std

--- a/test/pass/misc/08_config_file_default.c
+++ b/test/pass/misc/08_config_file_default.c
@@ -9,7 +9,7 @@
 // CHECK-NEXT: stats:           false
 // CHECK-NEXT: stack-lifetime:  true
 // CHECK-NEXT: typegen:         dimeta
-// CHECK-NEXT: filter:          true
+// CHECK-NEXT: filter:          false
 // CHECK-NEXT: call-filter:
 // CHECK-NEXT:   implementation:  std
 // CHECK-NEXT:   glob:            '*MPI_*'

--- a/test/pass/misc/08_config_file_default.c
+++ b/test/pass/misc/08_config_file_default.c
@@ -1,4 +1,4 @@
-// RUN: %c-to-llvm %s | %apply-typeart -typeart-config-dump -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart -S 2>&1 | %filecheck %s
 
 // CHECK-NOT: {{(Error|Fatal)}}
 
@@ -20,7 +20,6 @@
 // CHECK-NEXT:   filter-heap-alloca: false
 // CHECK-NEXT:   filter-pointer-alloca: true
 // CHECK-NEXT:   filter-non-array-alloca: false
-// CHECK-NEXT: file-format:     1
 
 void test() {
 }

--- a/test/pass/misc/09_config_file_cl.c
+++ b/test/pass/misc/09_config_file_cl.c
@@ -1,7 +1,7 @@
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-heap=true --typeart-stack=false -typeart-config=%S/07_typeart_config_stack.yml -S 2>&1 | %filecheck %s
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-heap=true -typeart-config=%S/07_typeart_config_stack.yml -S 2>&1 | %filecheck %s --check-prefix CHECK-HS
-// RUN: %c-to-llvm %s | %apply-typeart -typeart-config=%S/07_typeart_config_stack.yml -S 2>&1 | %filecheck %s --check-prefix CHECK-S
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-heap=true --typeart-stack=false --typeart-config=%S/07_typeart_config_stack.yml -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-heap=true --typeart-config=%S/07_typeart_config_stack.yml -S 2>&1 | %filecheck %s --check-prefix CHECK-HS
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-config=%S/07_typeart_config_stack.yml -S 2>&1 | %filecheck %s --check-prefix CHECK-S
 // clang-format on
 
 // Priority control with command line args vs. config file contents.

--- a/test/pass/misc/10_config_file_missing.c
+++ b/test/pass/misc/10_config_file_missing.c
@@ -1,4 +1,4 @@
-// RUN: %c-to-llvm %s | %apply-typeart -typeart-config=%S/missing_config.yml -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-config=%S/missing_config.yml -S 2>&1 | %filecheck %s
 // XFAIL: *
 // CHECK: Fatal
 

--- a/test/pass/stack/01_stack_lifetime.c
+++ b/test/pass/stack/01_stack_lifetime.c
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-stack-lifetime -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-stack-lifetime=true -S 2>&1 | %filecheck %s
 // clang-format on
 
 extern void type_check(void*);

--- a/test/pass/stack/01_stack_lifetime.c
+++ b/test/pass/stack/01_stack_lifetime.c
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack --typeart-stack-lifetime -S 2>&1 | %filecheck %s
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-stack-lifetime -S 2>&1 | %filecheck %s
 // clang-format on
 
 extern void type_check(void*);

--- a/test/pass/stack/02_stack_color.llin
+++ b/test/pass/stack/02_stack_color.llin
@@ -1,4 +1,4 @@
-; RUN: %apply-typeart --typeart-stack --typeart-stack-lifetime -S < %s | %filecheck %s
+; RUN: %apply-typeart --typeart-stack=true --typeart-stack-lifetime=true -S < %s | %filecheck %s
 
 ; REQUIRES: !dimeta
 

--- a/test/pass/stack/03_stack_nocolor.llin
+++ b/test/pass/stack/03_stack_nocolor.llin
@@ -1,4 +1,4 @@
-; RUN: %apply-typeart --typeart-stack --typeart-stack-lifetime -S < %s 2>&1 | %filecheck %s
+; RUN: %apply-typeart --typeart-stack=true --typeart-stack-lifetime=true -S < %s 2>&1 | %filecheck %s
 
 ; REQUIRES: !dimeta
 

--- a/test/runtime/52_stack_lifetime_2.llin
+++ b/test/runtime/52_stack_lifetime_2.llin
@@ -1,4 +1,4 @@
-; RUN: %apply-typeart --typeart-stack --typeart-stack-lifetime -S < %s | %llc -x=ir --filetype=obj -o %s.o
+; RUN: %apply-typeart --typeart-stack=true --typeart-stack-lifetime=true -S < %s | %llc -x=ir --filetype=obj -o %s.o
 ; RUN: %wrapper-cc %s.o -o %s.exe
 ; RUN: %s.exe 2>&1 | %filecheck %s
 


### PR DESCRIPTION
- Ability to accept env vars as config for the pass (TypeARTConfigureation.h priority: Env->Cmd line->File)
- Centralize TypeART related options and their defaults with TypeARTOptions.h
  - Used by MemInstFinder, Configurations
  - TypeARTConfiguration can produce and consume this struct
  - Can be dumped as yaml string
- Tests set values of typeart flags explicitly