### PR TITLE
Environment variable handling

### DIFF
--- a/lib/passes/Commandline.cpp
+++ b/lib/passes/Commandline.cpp
@@ -31,14 +31,14 @@ using namespace llvm;
 
 namespace typeart::config {
 
-namespace util {
+// namespace util {
 
-std::string get_type_file_path() {
-  auto flag_value = env::get_env_flag("TYPEART_TYPE_FILE");
-  return flag_value.value_or("types.yaml");
-}
+// std::string get_type_file_path() {
+//   auto flag_value = env::get_env_flag(config::EnvironmentStdArgs::types);
+//   return flag_value.value_or(ConfigStdArgValues::types);
+// }
 
-}  // namespace util
+// }  // namespace util
 
 namespace cl {
 struct CommandlineStdArgs final {
@@ -60,6 +60,7 @@ cl::OptionCategory typeart_category("TypeART instrumentation pass", "These contr
 
 static cl::opt<ConfigStdArgTypes::types_ty> cl_typeart_type_file(CommandlineStdArgs::types,
                                                                  cl::desc(ConfigStdArgDescriptions::types),
+                                                                 cl::init(ConfigStdArgValues::types),
                                                                  cl::cat(typeart_category));
 
 static cl::opt<ConfigStdArgTypes::stats_ty> cl_typeart_stats(CommandlineStdArgs::stats,
@@ -183,16 +184,16 @@ CommandLineOptions::CommandLineOptions() {
   using namespace config;
   using namespace typeart::config::cl::detail;
 
-  const auto type_file = [&]() {
-    if (!cl_typeart_type_file.empty()) {
-      LOG_DEBUG("Using cl::opt for types file " << cl_typeart_type_file.getValue());
-      return cl_typeart_type_file.getValue();
-    }
-    return util::get_type_file_path();
-  }();
+  // const auto type_file = [&]() {
+  //   if (!cl_typeart_type_file.empty()) {
+  //     LOG_DEBUG("Using cl::opt for types file " << cl_typeart_type_file.getValue());
+  //     return cl_typeart_type_file.getValue();
+  //   }
+  //   return util::get_type_file_path();
+  // }();
 
   mapping_ = {
-      make_entry(ConfigStdArgs::types, type_file),
+      make_entry(ConfigStdArgs::types, cl_typeart_type_file),
       make_entry(ConfigStdArgs::stats, cl_typeart_stats),
       make_entry(ConfigStdArgs::heap, cl_typeart_instrument_heap),
       make_entry(ConfigStdArgs::global, cl_typeart_instrument_global),

--- a/lib/passes/TypeARTConfiguration.cpp
+++ b/lib/passes/TypeARTConfiguration.cpp
@@ -17,6 +17,7 @@
 #include "configuration/EnvironmentConfiguration.h"
 #include "configuration/FileConfiguration.h"
 #include "configuration/TypeARTOptions.h"
+#include "support/ConfigurationBase.h"
 #include "support/Logger.h"
 
 #include <string>
@@ -96,9 +97,12 @@ TypeARTConfigOptions TypeARTConfiguration::getOptions() const {
 inline llvm::ErrorOr<std::unique_ptr<TypeARTConfiguration>> make_config(
     llvm::ErrorOr<std::unique_ptr<file::FileOptions>> file_opts) {
   if (file_opts) {
-    auto cl_opts  = std::make_unique<config::cl::CommandLineOptions>();
-    auto env_opts = std::make_unique<config::env::EnvironmentFlagsOptions>();
-    auto config   = std::make_unique<config::TypeARTConfiguration>(std::move(file_opts.get()), std::move(cl_opts),
+    const bool heap  = file_opts->get()->getValue(config::ConfigStdArgs::heap).value_or(OptionValue{false});
+    const bool stack = file_opts->get()->getValue(config::ConfigStdArgs::stack).value_or(OptionValue{false});
+    auto cl_opts     = std::make_unique<config::cl::CommandLineOptions>();
+    auto env_opts    = std::make_unique<config::env::EnvironmentFlagsOptions>();
+    env_opts->parsePhaseEnvFlags({heap, stack});
+    auto config = std::make_unique<config::TypeARTConfiguration>(std::move(file_opts.get()), std::move(cl_opts),
                                                                  std::move(env_opts));
     config->prioritizeCommandline(true);
     return config;

--- a/lib/passes/configuration/EnvironmentConfiguration.cpp
+++ b/lib/passes/configuration/EnvironmentConfiguration.cpp
@@ -52,13 +52,6 @@ struct EnvironmentStdArgsValues final {
 #undef TYPEART_CONFIG_OPTION
 };
 
-struct EnvironmentStdArgs final {
-#define TYPEART_CONFIG_OPTION(name, path, type, def_value, description, upper_path) \
-  static constexpr char name[] = "TYPEART_" upper_path;
-#include "support/ConfigurationBaseOptions.h"
-#undef TYPEART_CONFIG_OPTION
-};
-
 namespace detail {
 template <typename ClType>
 OptionValue make_opt(std::string_view cl_value) {
@@ -92,7 +85,7 @@ EnvironmentFlagsOptions::EnvironmentFlagsOptions() {
   LOG_DEBUG("Construct environment flag options")
 
   mapping_ = {
-      make_entry<std::string>(ConfigStdArgs::types, "TYPEART_TYPE_FILE", ConfigStdArgValues::types),
+      make_entry<std::string>(ConfigStdArgs::types, config::EnvironmentStdArgs::types, ConfigStdArgValues::types),
       make_entry<ConfigStdArgTypes::stats_ty>(ConfigStdArgs::stats, EnvironmentStdArgs::stats,
                                               EnvironmentStdArgsValues::stats),
       make_entry<ConfigStdArgTypes::heap_ty>(ConfigStdArgs::heap, EnvironmentStdArgs::heap,
@@ -131,7 +124,7 @@ EnvironmentFlagsOptions::EnvironmentFlagsOptions() {
   };
 
   occurence_mapping_ = {
-      make_occurr_entry(ConfigStdArgs::types, "TYPEART_TYPE_FILE"),
+      make_occurr_entry(ConfigStdArgs::types, config::EnvironmentStdArgs::types),
       make_occurr_entry(ConfigStdArgs::stats, EnvironmentStdArgs::stats),
       make_occurr_entry(ConfigStdArgs::heap, EnvironmentStdArgs::heap),
       make_occurr_entry(ConfigStdArgs::global, EnvironmentStdArgs::global),

--- a/lib/passes/configuration/EnvironmentConfiguration.h
+++ b/lib/passes/configuration/EnvironmentConfiguration.h
@@ -17,6 +17,11 @@
 
 namespace typeart::config::env {
 
+struct Phase {
+  bool heap;
+  bool stack;
+};
+
 std::optional<std::string> get_env_flag(std::string_view flag);
 
 class EnvironmentFlagsOptions final : public config::Configuration {
@@ -28,6 +33,7 @@ class EnvironmentFlagsOptions final : public config::Configuration {
   EnvironmentFlagsOptions();
   [[nodiscard]] std::optional<config::OptionValue> getValue(std::string_view opt_path) const override;
   [[maybe_unused]] [[nodiscard]] bool valueSpecified(std::string_view opt_path) const;
+  void parsePhaseEnvFlags(const Phase& phase);
 };
 
 }  // namespace typeart::config::env

--- a/lib/runtime/Runtime.cpp
+++ b/lib/runtime/Runtime.cpp
@@ -17,8 +17,8 @@
 #include "RuntimeData.h"
 #include "TypeIO.h"
 #include "TypeInterface.h"
+#include "support/ConfigurationBase.h"
 #include "support/Logger.h"
-
 // #include "llvm/Support/raw_ostream.h"
 
 #include <cstdlib>
@@ -62,7 +62,7 @@ inline void printTraceStart() {
 
 }  // namespace debug
 
-static constexpr const char* defaultTypeFileName = "types.yaml";
+static constexpr const char* defaultTypeFileName = config::ConfigStdArgValues::types;
 
 RuntimeSystem::RuntimeSystem() : rtScopeInit(), typeResolution(typeDB, recorder), allocTracker(typeDB, recorder) {
   debug::printTraceStart();
@@ -76,18 +76,18 @@ RuntimeSystem::RuntimeSystem() : rtScopeInit(), typeResolution(typeDB, recorder)
   std::error_code error;
   // Try to load types from specified file first.
   // Then look at default location.
-  const char* type_file = std::getenv("TYPEART_TYPE_FILE");
+  const char* type_file = std::getenv(config::EnvironmentStdArgs::types);
   if (type_file == nullptr) {
     // FIXME Deprecated name
-    type_file = std::getenv("TA_TYPE_FILE");
+    type_file = std::getenv("TYPEART_TYPE_FILE");
     if (type_file != nullptr) {
-      LOG_WARNING("Use of deprecated env var TA_TYPE_FILE.");
+      LOG_WARNING("Use of deprecated env var TYPEART_TYPE_FILE.");
     }
   }
   if (type_file != nullptr) {
     if (!loadTypes(type_file, error)) {
-      LOG_FATAL("Failed to load recorded types from TYPEART_TYPE_FILE=" << type_file
-                                                                        << ". Reason: " << error.message());
+      LOG_FATAL("Failed to load recorded types from " << config::EnvironmentStdArgs::types << "=" << type_file
+                                                      << " .Reason: " << error.message());
       std::exit(EXIT_FAILURE);  // TODO: Error handling
     }
   } else {

--- a/lib/support/ConfigurationBase.h
+++ b/lib/support/ConfigurationBase.h
@@ -43,6 +43,13 @@ struct ConfigStdArgDescriptions final {
 #undef TYPEART_CONFIG_OPTION
 };
 
+struct EnvironmentStdArgs final {
+#define TYPEART_CONFIG_OPTION(name, path, type, def_value, description, upper_path) \
+  static constexpr char name[] = "TYPEART_" upper_path;
+#include "support/ConfigurationBaseOptions.h"
+#undef TYPEART_CONFIG_OPTION
+};
+
 }  // namespace typeart::config
 
 #endif /* TYPEART_CONFIG_OPTION_BASE_H */

--- a/scripts/typeart_ir_viewer.py
+++ b/scripts/typeart_ir_viewer.py
@@ -115,7 +115,7 @@ def make_typeart_ir(config):
     env = {
         **os.environ,
         "TYPEART_WRAPPER_EMIT_IR": "1",
-        "TYPEART_TYPE_FILE": str(config.types_file),
+        "TYPEART_TYPES": str(config.types_file),
     }
     subprocess.check_call([typeart_wrapper] + config.wrapper_args + [config.source_file], env=env,
                           cwd=source_dir)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -79,7 +79,7 @@ else:
 
 config.environment['LLVM_PROFILE_FILE'] = profile_files
 
-typeart_types_d = 'TYPEART_TYPE_FILE=%basename_t.yaml'
+typeart_types_d = 'TYPEART_TYPES=%basename_t.yaml'
 
 if config.environment['TYPEART_TYPEGEN_IR'] == '1':
   std_plugin_args_newpm += ';typegen=ir'

--- a/test/pass/misc/11_env_flags.c
+++ b/test/pass/misc/11_env_flags.c
@@ -1,0 +1,17 @@
+// clang-format off
+// RUN: %c-to-llvm %s | TYPEART_OPTIONS="no-heap;no-stack;no-stats;no-stack-lifetime" %apply-typeart 2>&1 | %filecheck %s
+
+// CHECK: Emitting TypeART configuration content
+// CHECK-NEXT: ---
+// CHECK-NEXT: types:           {{.*}}
+// CHECK-NEXT: heap:            false
+// CHECK-NEXT: stack:           false
+// CHECK-NEXT: global:          false
+// CHECK-NEXT: stats:          false
+// CHECK-NEXT: stack-lifetime:          false
+
+// clang-format on
+
+void test() {
+  int a;
+}

--- a/test/pass/misc/12_env_flags_single_override.c
+++ b/test/pass/misc/12_env_flags_single_override.c
@@ -1,0 +1,17 @@
+// clang-format off
+// RUN: %c-to-llvm %s | TYPEART_OPTIONS="no-heap;no-stack;no-stats;no-stack-lifetime" TYPEART_HEAP=true %apply-typeart 2>&1 | %filecheck %s
+
+// CHECK: Emitting TypeART configuration content
+// CHECK-NEXT: ---
+// CHECK-NEXT: types:           {{.*}}
+// CHECK-NEXT: heap:            true
+// CHECK-NEXT: stack:           false
+// CHECK-NEXT: global:          false
+// CHECK-NEXT: stats:          false
+// CHECK-NEXT: stack-lifetime:          false
+
+// clang-format on
+
+void test() {
+  int a;
+}

--- a/test/pass/misc/13_env_flags_phase_heap.c
+++ b/test/pass/misc/13_env_flags_phase_heap.c
@@ -1,0 +1,17 @@
+// clang-format off
+// RUN: %c-to-llvm %s | TYPEART_OPTIONS_HEAP="stack;no-stats;no-stack-lifetime" %apply-typeart 2>&1 | %filecheck %s
+
+// CHECK: Emitting TypeART configuration content
+// CHECK-NEXT: ---
+// CHECK-NEXT: types:           {{.*}}
+// CHECK-NEXT: heap:            true
+// CHECK-NEXT: stack:           true
+// CHECK-NEXT: global:          true
+// CHECK-NEXT: stats:          false
+// CHECK-NEXT: stack-lifetime:          false
+
+// clang-format on
+
+void test() {
+  int a;
+}

--- a/test/pass/misc/14_env_flags_phase_ignored.c
+++ b/test/pass/misc/14_env_flags_phase_ignored.c
@@ -1,0 +1,15 @@
+// clang-format off
+// RUN: %c-to-llvm %s | TYPEART_OPTIONS_STACK="global;stack;no-stats;no-stack-lifetime" %apply-typeart 2>&1 | %filecheck %s
+
+// CHECK: Emitting TypeART configuration content
+// CHECK: heap:            true
+// CHECK-NOT: stack:           true
+// CHECK-NOT: {{^}}global:          true
+// CHECK-NOT: stats:          false
+// CHECK-NOT: stack-lifetime:          false
+
+// clang-format on
+
+void test() {
+  int a;
+}

--- a/test/pass/new_delete/20_no_array_cookie_lulesh_ad.llin
+++ b/test/pass/new_delete/20_no_array_cookie_lulesh_ad.llin
@@ -1,4 +1,4 @@
-; RUN: %apply-typeart -S < %s
+; RUN: %apply-typeart -S < %s | %filecheck %s
 ; REQUIRES: llvm-18
 
 ; llvm-reduce on lulesh.cc with culprit chunk.hpp:allocateData() where pattern is similar to array cookie.


### PR DESCRIPTION
- Use "types" from config base options; TYPEART_TYPE_FILE is deprecated, now TYPEART_TYPES
- Phase specific environment options: TYPEART_OPTIONS_STACK, TYPEART_OPTIONS_HEAP, only parsed for activated stack or heap phase respectively