### PR TITLE
CI Optimization and Test Modernization

### DIFF
--- a/.github/workflows/basic-ci.yml
+++ b/.github/workflows/basic-ci.yml
@@ -44,7 +44,7 @@ jobs:
           git status --porcelain --untracked-files=no | xargs -o -I {} test -z \"{}\"
 
   codespell:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v6
@@ -75,6 +75,14 @@ jobs:
           - { os: ubuntu-24.04, llvm-version: 20, typeart-typegen-legacy: 0 }
           - { os: ubuntu-24.04, llvm-version: 21, typeart-typegen-legacy: 0 }
           - { os: ubuntu-24.04, llvm-version: 22, typeart-typegen-legacy: 0 }
+        include:
+          - preset:
+              name: ci-thread-safe
+              abseil: true
+            platform:
+              os: ubuntu-24.04
+              llvm-version: 22
+              typeart-typegen-legacy: 0
 
     runs-on: ${{ matrix.platform.os }}
 
@@ -92,7 +100,11 @@ jobs:
           setup-mold: 'true'
 
       - name: Configure TypeART
-        run: cmake -B build --preset ${{ matrix.preset.name }} -DLLVM_DIR=${LLVM_CMAKE_DIR} -DLLVM_EXTERNAL_LIT=${EXTERNAL_LIT}
+        run: >
+          cmake -B build --preset ${{ matrix.preset.name }}
+          -DLLVM_DIR=${LLVM_CMAKE_DIR}
+          -DLLVM_EXTERNAL_LIT=${EXTERNAL_LIT}
+          ${{ matrix.preset.abseil && '-DTYPEART_ABSEIL=ON -DTYPEART_PHMAP=OFF' || '' }}
 
       - name: Build TypeART
         run: cmake --build build --parallel 2

--- a/.github/workflows/ext-ci.yml
+++ b/.github/workflows/ext-ci.yml
@@ -21,9 +21,6 @@ jobs:
         platform:
           - { os: ubuntu-22.04, llvm-version: 14 }
           - { os: ubuntu-24.04, llvm-version: 18 }
-          - { os: ubuntu-24.04, llvm-version: 19 }
-          - { os: ubuntu-24.04, llvm-version: 20 }
-          - { os: ubuntu-24.04, llvm-version: 21 }
           - { os: ubuntu-24.04, llvm-version: 22 }
 
     runs-on: ${{ matrix.platform.os }}
@@ -117,9 +114,6 @@ jobs:
         platform:
           - { os: ubuntu-22.04, llvm-version: 14 }
           - { os: ubuntu-24.04, llvm-version: 18 }
-          - { os: ubuntu-24.04, llvm-version: 19 }
-          - { os: ubuntu-24.04, llvm-version: 20 }
-          - { os: ubuntu-24.04, llvm-version: 21 }
           - { os: ubuntu-24.04, llvm-version: 22 }
 
     runs-on: ${{ matrix.platform.os }}
@@ -201,9 +195,6 @@ jobs:
         platform:
           - { os: ubuntu-22.04, llvm-version: 14 }
           - { os: ubuntu-24.04, llvm-version: 18 }
-          - { os: ubuntu-24.04, llvm-version: 19 }
-          - { os: ubuntu-24.04, llvm-version: 20 }
-          - { os: ubuntu-24.04, llvm-version: 21 }
           - { os: ubuntu-24.04, llvm-version: 22 }
 
     runs-on: ${{ matrix.platform.os }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -139,6 +139,8 @@
       "cacheVariables": {
         "TYPEART_ASAN": "OFF",
         "TYPEART_UBSAN": "OFF",
+        "TYPEART_ABSEIL": "OFF",
+        "TYPEART_PHMAP": "OFF",
         "TYPEART_CI_RUN": "ON"
       }
     },

--- a/test/pass/arrays/01_simple_array.c
+++ b/test/pass/arrays/01_simple_array.c
@@ -1,6 +1,5 @@
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-stack-lifetime=false -S 2>&1 | %filecheck %s --check-prefixes CHECK,ALLOC
-// REQUIRES: llvm-14
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-stack-lifetime=false -S 2>&1 | %filecheck %s --check-prefixes CHECK,%llvm-version-check
 // clang-format on
 void test() {
   int a[100];
@@ -11,10 +10,12 @@ void test() {
 
 // CHECK: @test()
 // CHECK: %__ta_alloca_counter = alloca i32
-// CHECK-NEXT: store i32 0, i32* %__ta_alloca_counter
+// CHECK-NEXT: store i32 0, {{i32\*|ptr}} %__ta_alloca_counter
 
-// ALLOC: [[POINTER:%[0-9a-z]+]] = alloca [100 x i32]
-// ALLOC-NEXT: [[POINTER2:%[0-9a-z]+]] = bitcast [100 x i32]* [[POINTER]] to i8*
-// ALLOC-NEXT: call void @__typeart_alloc_stack(i8* [[POINTER2]], i32 13, i64 100)
+// LLVM_LEGACY: [[POINTER:%[0-9a-z]+]] = alloca [100 x i32]
+// LLVM_LEGACY-NEXT: [[POINTER2:%[0-9a-z]+]] = bitcast [100 x i32]* [[POINTER]] to i8*
+// LLVM_LEGACY-NEXT: call void @__typeart_alloc_stack(i8* [[POINTER2]], i32 13, i64 100)
+// LLVM: [[POINTER:%[0-9a-z]+]] = alloca [100 x i32]
+// LLVM-NEXT: call void @__typeart_alloc_stack(ptr [[POINTER]], i32 13, i64 100)
 
 // CHECK: call void @__typeart_leave_scope(i32 %__ta_counter_load)

--- a/test/pass/arrays/02_array_to_pointer.c
+++ b/test/pass/arrays/02_array_to_pointer.c
@@ -1,6 +1,5 @@
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-analysis-filter-pointer-alloca=false --typeart-stack-lifetime=false -S 2>&1 | %filecheck %s
-// REQUIRES: llvm-14
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-analysis-filter-pointer-alloca=false --typeart-stack-lifetime=false -S 2>&1 | %filecheck %s --check-prefixes CHECK,%llvm-version-check
 // clang-format on
 void test() {
   int a[100];
@@ -13,10 +12,12 @@ void test() {
 
 // CHECK: @test()
 // CHECK: %__ta_alloca_counter = alloca i32
-// CHECK-NEXT: store i32 0, i32* %__ta_alloca_counter
+// CHECK-NEXT: store i32 0, {{i32\*|ptr}} %__ta_alloca_counter
 
-// CHECK: [[POINTER:%[0-9a-z]+]] = alloca [100 x i32]
-// CHECK-NEXT: [[POINTER2:%[0-9a-z]+]] = bitcast [100 x i32]* [[POINTER]] to i8*
-// CHECK-NEXT: call void @__typeart_alloc_stack(i8* [[POINTER2]], i32 13, i64 100)
+// LLVM_LEGACY: [[POINTER:%[0-9a-z]+]] = alloca [100 x i32]
+// LLVM_LEGACY-NEXT: [[POINTER2:%[0-9a-z]+]] = bitcast [100 x i32]* [[POINTER]] to i8*
+// LLVM_LEGACY-NEXT: call void @__typeart_alloc_stack(i8* [[POINTER2]], i32 13, i64 100)
+// LLVM: [[POINTER:%[0-9a-z]+]] = alloca [100 x i32]
+// LLVM-NEXT: call void @__typeart_alloc_stack(ptr [[POINTER]], i32 13, i64 100)
 
 // CHECK: call void @__typeart_leave_scope(i32 %__ta_counter_load)

--- a/test/pass/filter/16_omp_reduction.c
+++ b/test/pass/filter/16_omp_reduction.c
@@ -2,9 +2,8 @@
 // RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s
 // RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true -S 2>&1 | %filecheck %s
 
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefix=check-inst
-// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefix=check-inst
-// REQUIRES: llvm-14
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefixes check-inst,%llvm-version-check
+// RUN: %c-to-llvm -fno-discard-value-names %omp_c_flags %s | %opt -O2 -S | %apply-typeart --typeart-stack=true --typeart-filter=true -S | %filecheck %s --check-prefixes check-inst,%llvm-version-check
 // REQUIRES: openmp
 // clang-format on
 
@@ -24,8 +23,9 @@ void foo() {
   float array[n] = {0};
   // check-inst: define {{.*}} @foo
   // check-inst: %loc = alloca
-  // check-inst: [[POINTER:%[0-9a-z]+]] = bitcast float* %loc to i8*
-  // check-inst: call void @__typeart_alloc_stack(i8* [[POINTER]], i32 23, i64 1)
+  // LLVM_LEGACY: [[POINTER:%[0-9a-z]+]] = bitcast float* %loc to i8*
+  // LLVM_LEGACY: call void @__typeart_alloc_stack(i8* [[POINTER]], i32 23, i64 1)
+  // LLVM: call void @__typeart_alloc_stack(ptr %loc, i32 23, i64 1)
   // check-inst-not: __typeart_alloc_stack_omp
   float loc      = sum(array, n);
   MPI_send((void*)&loc);

--- a/test/pass/global/01_globals.c
+++ b/test/pass/global/01_globals.c
@@ -1,4 +1,6 @@
+// clang-format off
 // RUN: %c-to-llvm %s | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s --check-prefixes CHECK,%llvm-version-check
+// clang-format on
 
 int global;
 int global_2 = 0;

--- a/test/pass/global/01_globals.c
+++ b/test/pass/global/01_globals.c
@@ -1,5 +1,4 @@
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s
-// REQUIRES: llvm-14
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s --check-prefixes CHECK,%llvm-version-check
 
 int global;
 int global_2 = 0;
@@ -20,8 +19,12 @@ void foo() {
 
 // CHECK: void @__typeart_init_module_
 // CHECK-NEXT: entry:
-// CHECK-DAG: call void @__typeart_alloc_global(i8* bitcast (i32* @global to i8*)
-// CHECK-DAG: call void @__typeart_alloc_global(i8* bitcast (i32* @global_2 to i8*)
-// CHECK-DAG: call void @__typeart_alloc_global(i8* bitcast (i32* @global_5 to i8*)
-// CHECK-DAG: call void @__typeart_alloc_global(i8* bitcast (i32* @global_6 to i8*)
+// LLVM_LEGACY-DAG: call void @__typeart_alloc_global(i8* bitcast (i32* @global to i8*)
+// LLVM-DAG: call void @__typeart_alloc_global(ptr @global,
+// LLVM_LEGACY-DAG: call void @__typeart_alloc_global(i8* bitcast (i32* @global_2 to i8*)
+// LLVM-DAG: call void @__typeart_alloc_global(ptr @global_2,
+// LLVM_LEGACY-DAG: call void @__typeart_alloc_global(i8* bitcast (i32* @global_5 to i8*)
+// LLVM-DAG: call void @__typeart_alloc_global(ptr @global_5,
+// LLVM_LEGACY-DAG: call void @__typeart_alloc_global(i8* bitcast (i32* @global_6 to i8*)
+// LLVM-DAG: call void @__typeart_alloc_global(ptr @global_6,
 // CHECK: ret void

--- a/test/pass/global/04_const_char.c
+++ b/test/pass/global/04_const_char.c
@@ -1,5 +1,4 @@
 // RUN: %c-to-llvm %s | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s
-// REQUIRES: llvm-14
 
 // REQUIRES: !dimeta
 

--- a/test/pass/global/05_asan.c
+++ b/test/pass/global/05_asan.c
@@ -1,5 +1,4 @@
-// RUN: %c-to-llvm %s -fsanitize=address | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s
-// REQUIRES: llvm-14
+// RUN: %c-to-llvm %s -fsanitize=address | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s --check-prefixes CHECK,%llvm-version-check
 
 // REQUIRES: asan
 
@@ -14,6 +13,9 @@ void foo() {
 
 // CHECK: void @__typeart_init_module_
 // CHECK-NEXT: entry:
-// CHECK-NEXT: call void @__typeart_alloc_global(i8* bitcast (i32* @global_2 to i8*)
-// CHECK-NEXT: call void @__typeart_alloc_global(i8* bitcast (i32* @global to i8*)
-// CHECK-NEXT: ret void
+// LLVM_LEGACY-NEXT: call void @__typeart_alloc_global(i8* bitcast ({{[^@]+}} @global_2 to i8*)
+// LLVM-NEXT: call void @__typeart_alloc_global(ptr @global_2,
+// LLVM_LEGACY-NEXT: call void @__typeart_alloc_global(i8* bitcast ({{[^@]+}} @global to i8*)
+// LLVM-NEXT: call void @__typeart_alloc_global(ptr @global,
+// LLVM_LEGACY-NEXT: ret void
+// LLVM-NEXT: ret void

--- a/test/pass/global/05_asan.c
+++ b/test/pass/global/05_asan.c
@@ -1,4 +1,6 @@
+// clang-format off
 // RUN: %c-to-llvm %s -fsanitize=address | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s --check-prefixes CHECK,%llvm-version-check
+// clang-format on
 
 // REQUIRES: asan
 

--- a/test/pass/global/06_coverage.c
+++ b/test/pass/global/06_coverage.c
@@ -1,4 +1,6 @@
+// clang-format off
 // RUN: %c-to-llvm --coverage %s | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s --check-prefixes CHECK,%llvm-version-check
+// clang-format on
 
 int global;
 int global_2 = 0;

--- a/test/pass/global/06_coverage.c
+++ b/test/pass/global/06_coverage.c
@@ -1,5 +1,4 @@
-// RUN: %c-to-llvm --coverage %s | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s
-// REQUIRES: llvm-14
+// RUN: %c-to-llvm --coverage %s | %apply-typeart --typeart-global=true -S 2>&1 | %filecheck %s --check-prefixes CHECK,%llvm-version-check
 
 int global;
 int global_2 = 0;
@@ -13,6 +12,9 @@ void foo() {
 
 // CHECK: void @__typeart_init_module_
 // CHECK-NEXT: entry:
-// CHECK-NEXT: call void @__typeart_alloc_global(i8* bitcast (i32* @global_2 to i8*)
-// CHECK-NEXT: call void @__typeart_alloc_global(i8* bitcast (i32* @global to i8*)
-// CHECK-NEXT: ret void
+// LLVM_LEGACY-NEXT: call void @__typeart_alloc_global(i8* bitcast ({{[^@]+}} @global_2 to i8*)
+// LLVM-NEXT: call void @__typeart_alloc_global(ptr @global_2,
+// LLVM_LEGACY-NEXT: call void @__typeart_alloc_global(i8* bitcast ({{[^@]+}} @global to i8*)
+// LLVM-NEXT: call void @__typeart_alloc_global(ptr @global,
+// LLVM_LEGACY-NEXT: ret void
+// LLVM-NEXT: ret void

--- a/test/pass/global/07_coverage_llvm.c
+++ b/test/pass/global/07_coverage_llvm.c
@@ -1,6 +1,5 @@
 // RUN: %c-to-llvm -fprofile-instr-generate -fcoverage-mapping %s | %apply-typeart --typeart-global=true -S 2>&1 \
-// RUN: | %filecheck %s
-// REQUIRES: llvm-14
+// RUN: | %filecheck %s --check-prefixes CHECK,%llvm-version-check
 
 int global;
 int global_2 = 0;
@@ -14,6 +13,9 @@ void foo() {
 
 // CHECK: void @__typeart_init_module_
 // CHECK-NEXT: entry:
-// CHECK-NEXT: call void @__typeart_alloc_global(i8* bitcast (i32* @global_2 to i8*)
-// CHECK-NEXT: call void @__typeart_alloc_global(i8* bitcast (i32* @global to i8*)
-// CHECK-NEXT: ret void
+// LLVM_LEGACY-NEXT: call void @__typeart_alloc_global(i8* bitcast ({{[^@]+}} @global_2 to i8*)
+// LLVM-NEXT: call void @__typeart_alloc_global(ptr @global_2,
+// LLVM_LEGACY-NEXT: call void @__typeart_alloc_global(i8* bitcast ({{[^@]+}} @global to i8*)
+// LLVM-NEXT: call void @__typeart_alloc_global(ptr @global,
+// LLVM_LEGACY-NEXT: ret void
+// LLVM-NEXT: ret void

--- a/test/pass/malloc_free/16_omp_heap.c
+++ b/test/pass/malloc_free/16_omp_heap.c
@@ -1,6 +1,5 @@
 // clang-format off
-// RUN: %c-to-llvm %omp_c_flags %s | %apply-typeart -S 2>&1 | %filecheck %s
-// REQUIRES: llvm-14
+// RUN: %c-to-llvm %omp_c_flags %s | %apply-typeart -S 2>&1 | %filecheck %s --check-prefixes CHECK,%llvm-version-check
 // REQUIRES: openmp
 // clang-format on
 
@@ -26,19 +25,27 @@ void foo(int** x) {
 // CHECK-NEXT: Free{{[ ]*}}:{{[ ]*}}1
 // CHECK-NEXT: Alloca{{[ ]*}}:{{[ ]*}}0
 
-// CHECK: [[POINTER:%[0-9a-z]+]] = call noalias{{( align [0-9]+)?}} i8* @calloc(i64{{( noundef)?}} [[SIZE:[0-9a-z]+]], i64{{( noundef)?}} 8)
-// CHECK-NEXT: call void @__typeart_alloc_omp(i8* [[POINTER]], i32 24, i64 [[SIZE]])
-// CHECK-NEXT: bitcast i8* [[POINTER]] to double*
+// LLVM_LEGACY: [[POINTER:%[0-9a-z]+]] = call noalias{{( align [0-9]+)?}} i8* @calloc(i64{{( noundef)?}} [[SIZE:[0-9a-z]+]], i64{{( noundef)?}} 8)
+// LLVM_LEGACY-NEXT: call void @__typeart_alloc_omp(i8* [[POINTER]], i32 24, i64 [[SIZE]])
+// LLVM_LEGACY-NEXT: bitcast i8* [[POINTER]] to double*
+// LLVM: [[POINTER:%[0-9a-z]+]] = call noalias{{( align [0-9]+)?}} ptr @calloc(i64{{( noundef)?}} [[SIZE:[0-9a-z]+]], i64{{( noundef)?}} 8)
+// LLVM-NEXT: call void @__typeart_alloc(ptr [[POINTER]], i32 24, i64 [[SIZE]])
 
-// CHECK: __typeart_free_omp(i8* [[POINTER:%[0-9a-z]+]])
-// CHECK-NEXT: [[POINTER2:%[0-9a-z]+]] = call{{( align [0-9]+)?}} i8* @realloc(i8*{{( noundef)?}} [[POINTER]], i64{{( noundef)?}} 160)
-// CHECK-NEXT: __typeart_alloc_omp(i8* [[POINTER2]], i32 24, i64 20)
+// LLVM_LEGACY: __typeart_free_omp(i8* [[POINTER:%[0-9a-z]+]])
+// LLVM_LEGACY-NEXT: [[POINTER2:%[0-9a-z]+]] = call{{( align [0-9]+)?}} i8* @realloc(i8*{{( noundef)?}} [[POINTER]], i64{{( noundef)?}} 160)
+// LLVM_LEGACY-NEXT: __typeart_alloc_omp(i8* [[POINTER2]], i32 24, i64 20)
+// LLVM: __typeart_free(ptr [[POINTER:%[0-9a-z]+]])
+// LLVM-NEXT: [[POINTER2:%[0-9a-z]+]] = call{{( align [0-9]+)?}} ptr @realloc(ptr{{( noundef)?}} [[POINTER]], i64{{( noundef)?}} 160)
+// LLVM-NEXT: __typeart_alloc(ptr [[POINTER2]], i32 24, i64 20)
 
-// CHECK: [[POINTER:%[0-9a-z]+]] = call noalias{{( align [0-9]+)?}} i8* @malloc
-// CHECK-NEXT: call void @__typeart_alloc_omp(i8* [[POINTER]], i32 13, i64 8)
-// CHECK-NEXT: bitcast i8* [[POINTER]] to i32*
+// LLVM_LEGACY: [[POINTER:%[0-9a-z]+]] = call noalias{{( align [0-9]+)?}} i8* @malloc
+// LLVM_LEGACY-NEXT: call void @__typeart_alloc_omp(i8* [[POINTER]], i32 13, i64 8)
+// LLVM_LEGACY-NEXT: bitcast i8* [[POINTER]] to i32*
+// LLVM: [[POINTER:%[0-9a-z]+]] = call noalias{{( align [0-9]+)?}} ptr @malloc
+// LLVM-NEXT: call void @__typeart_alloc(ptr [[POINTER]], i32 13, i64 8)
 
 // CHECK: call void @free
-// CHECK-NEXT: call void @__typeart_free_omp
+// LLVM_LEGACY-NEXT: call void @__typeart_free_omp
+// LLVM-NEXT: call void @__typeart_free
 
 // clang-format on

--- a/test/pass/misc/03_make_mismatch_callback.c
+++ b/test/pass/misc/03_make_mismatch_callback.c
@@ -1,5 +1,4 @@
 // RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true -S 2>&1 | %filecheck %s
-// REQUIRES: llvm-14
 // XFAIL: *
 
 #include <stddef.h>

--- a/test/pass/misc/07_config_file.c
+++ b/test/pass/misc/07_config_file.c
@@ -1,5 +1,4 @@
 // RUN: %c-to-llvm %s | %apply-typeart --typeart-config=%S/07_typeart_config_stack.yml 2>&1 | %filecheck %s
-// REQUIRES: llvm-14
 
 #include <stdlib.h>
 void test() {

--- a/test/pass/misc/09_config_file_cl.c
+++ b/test/pass/misc/09_config_file_cl.c
@@ -2,7 +2,6 @@
 // RUN: %c-to-llvm %s | %apply-typeart --typeart-heap=true --typeart-stack=false --typeart-config=%S/07_typeart_config_stack.yml -S 2>&1 | %filecheck %s
 // RUN: %c-to-llvm %s | %apply-typeart --typeart-heap=true --typeart-config=%S/07_typeart_config_stack.yml -S 2>&1 | %filecheck %s --check-prefix CHECK-HS
 // RUN: %c-to-llvm %s | %apply-typeart --typeart-config=%S/07_typeart_config_stack.yml -S 2>&1 | %filecheck %s --check-prefix CHECK-S
-// REQUIRES: llvm-14
 // clang-format on
 
 // Priority control with command line args vs. config file contents.

--- a/test/pass/misc/10_config_file_missing.c
+++ b/test/pass/misc/10_config_file_missing.c
@@ -1,5 +1,4 @@
 // RUN: %c-to-llvm %s | %apply-typeart --typeart-config=%S/missing_config.yml -S 2>&1 | %filecheck %s
-// REQUIRES: llvm-14
 // XFAIL: *
 // CHECK: Fatal
 

--- a/test/pass/new_delete/17_array_cookie_dynamic_size.cpp
+++ b/test/pass/new_delete/17_array_cookie_dynamic_size.cpp
@@ -1,6 +1,5 @@
 // clang-format off
-// RUN: %cpp-to-llvm %s | %apply-typeart -S 2>&1 | %filecheck %s
-// REQUIRES: llvm-14
+// RUN: %cpp-to-llvm %s | %apply-typeart -S 2>&1 | %filecheck %s --check-prefixes CHECK,%llvm-version-check
 // clang-format on
 
 // CHECK: TypeArtPass [Heap]
@@ -13,12 +12,16 @@ struct S1 {
   ~S1() {};
 };
 
-// CHECK: [[MEM:%[0-9a-z]+]] = call{{.*}} i8* @_Znam(i64{{( noundef)?}} [[ALLOC:%[0-9a-z]+]])
-// CHECK: [[COOKIE:%[0-9a-z]+]] = bitcast i8* [[MEM]] to i64*
-// CHECK: store i64 [[COUNT:%[0-9a-z]+]], i64* [[COOKIE]], align 8
-// CHECK: [[ARR:%[0-9a-z]+]] = getelementptr inbounds i8, i8* [[MEM]], i64 8
-// CHECK: call void @__typeart_alloc(i8* [[ARR]], i32 {{2[0-9]+}}, i64 [[COUNT]])
-// CHECK: bitcast i8* [[ARR]] to %struct.S1*
+// LLVM_LEGACY: [[MEM:%[0-9a-z]+]] = call{{.*}} i8* @_Znam(i64{{( noundef)?}} [[ALLOC:%[0-9a-z]+]])
+// LLVM_LEGACY: [[COOKIE:%[0-9a-z]+]] = bitcast i8* [[MEM]] to i64*
+// LLVM_LEGACY: store i64 [[COUNT:%[0-9a-z]+]], i64* [[COOKIE]], align 8
+// LLVM_LEGACY: [[ARR:%[0-9a-z]+]] = getelementptr inbounds i8, i8* [[MEM]], i64 8
+// LLVM_LEGACY: call void @__typeart_alloc(i8* [[ARR]], i32 {{2[0-9]+}}, i64 [[COUNT]])
+// LLVM_LEGACY: bitcast i8* [[ARR]] to %struct.S1*
+// LLVM: [[MEM:%[0-9a-z]+]] = call{{.*}} ptr @_Znam(i64{{( noundef)?}} [[ALLOC:%[0-9a-z]+]])
+// LLVM: store i64 [[COUNT:%[0-9a-z]+]], ptr [[MEM]], align 8
+// LLVM: [[ARR:%[0-9a-z]+]] = getelementptr inbounds i8, ptr [[MEM]], i64 8
+// LLVM: call void @__typeart_alloc{{(_mty)?}}(ptr [[ARR]]
 int main() {
   volatile int elment_count = 2;
   S1* ss                    = new S1[elment_count];

--- a/test/pass/stack/01_stack_lifetime.c
+++ b/test/pass/stack/01_stack_lifetime.c
@@ -1,6 +1,5 @@
 // clang-format off
-// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-stack-lifetime=true -S 2>&1 | %filecheck %s
-// REQUIRES: llvm-14
+// RUN: %c-to-llvm %s | %apply-typeart --typeart-stack=true --typeart-stack-lifetime=true -S 2>&1 | %filecheck %s --check-prefixes %llvm-version-check
 // clang-format on
 
 extern void type_check(void*);
@@ -16,9 +15,13 @@ void correct(int rank) {
   }
 }
 
-// CHECK: [[POINTER:%[0-9a-z]+]] = bitcast [3 x [3 x i32]]* [[BUF:%[0-9a-z]+]] to i8*
-// CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 36, i8* [[POINTER]])
-// CHECK-NEXT: call void @__typeart_alloc_stack(i8* [[POINTER]], i32 13, i64 9)
+// LLVM_LEGACY: [[POINTER:%[0-9a-z]+]] = bitcast [3 x [3 x i32]]* [[BUF:%[0-9a-z]+]] to i8*
+// LLVM_LEGACY-NEXT: call void @llvm.lifetime.start.p0i8(i64 36, i8* [[POINTER]])
+// LLVM_LEGACY-NEXT: call void @__typeart_alloc_stack(i8* [[POINTER]], i32 13, i64 9)
+// LLVM: call void @llvm.lifetime.start.p0(i64 36, ptr [[POINTER:%[0-9a-z]+]])
+// LLVM: call void @__typeart_alloc_stack(ptr [[POINTER]], i32 13, i64 9)
 
-// CHECK: call void @llvm.lifetime.start.p0i8(i64 12, i8* [[POINTER2:%[0-9a-z]+]])
-// CHECK-NEXT: call void @__typeart_alloc_stack(i8* [[POINTER2]], i32 13, i64 3)
+// LLVM_LEGACY: call void @llvm.lifetime.start.p0i8(i64 12, i8* [[POINTER2:%[0-9a-z]+]])
+// LLVM_LEGACY-NEXT: call void @__typeart_alloc_stack(i8* [[POINTER2]], i32 13, i64 3)
+// LLVM: call void @llvm.lifetime.start.p0(i64 12, ptr [[POINTER2:%[0-9a-z]+]])
+// LLVM: call void @__typeart_alloc_stack(ptr [[POINTER2]], i32 13, i64 3)

--- a/test/pass/stack/01_stack_lifetime.c
+++ b/test/pass/stack/01_stack_lifetime.c
@@ -18,10 +18,10 @@ void correct(int rank) {
 // LLVM_LEGACY: [[POINTER:%[0-9a-z]+]] = bitcast [3 x [3 x i32]]* [[BUF:%[0-9a-z]+]] to i8*
 // LLVM_LEGACY-NEXT: call void @llvm.lifetime.start.p0i8(i64 36, i8* [[POINTER]])
 // LLVM_LEGACY-NEXT: call void @__typeart_alloc_stack(i8* [[POINTER]], i32 13, i64 9)
-// LLVM: call void @llvm.lifetime.start.p0(i64 36, ptr [[POINTER:%[0-9a-z]+]])
+// LLVM: call void @llvm.lifetime.start.p0({{(i64 36, )?}}ptr [[POINTER:%[0-9a-z]+]])
 // LLVM: call void @__typeart_alloc_stack(ptr [[POINTER]], i32 13, i64 9)
 
 // LLVM_LEGACY: call void @llvm.lifetime.start.p0i8(i64 12, i8* [[POINTER2:%[0-9a-z]+]])
 // LLVM_LEGACY-NEXT: call void @__typeart_alloc_stack(i8* [[POINTER2]], i32 13, i64 3)
-// LLVM: call void @llvm.lifetime.start.p0(i64 12, ptr [[POINTER2:%[0-9a-z]+]])
+// LLVM: call void @llvm.lifetime.start.p0({{(i64 12, )?}}ptr [[POINTER2:%[0-9a-z]+]])
 // LLVM: call void @__typeart_alloc_stack(ptr [[POINTER2]], i32 13, i64 3)


### PR DESCRIPTION
- CI: improve runtime by using std::map instead of Abseil and streamlining the external benchmark matrix (LLVM 14, 18, 22). 
- Test suite: more support of LLVM versions (14 through 22) specifically w.r.t. the transition to opaque pointers.